### PR TITLE
resolve potential deadlocks

### DIFF
--- a/src/headers/advanced-scene-switcher.hpp
+++ b/src/headers/advanced-scene-switcher.hpp
@@ -228,10 +228,8 @@ void setNextTransition(OBSWeakSource &targetScene, obs_source_t *currentSource,
 void overwriteTransitionOverride(obs_weak_source_t *sceneWs,
 				 obs_source_t *transition, transitionData &td);
 void restoreTransitionOverride(obs_source_t *scene, transitionData td);
-
 void switchScene(OBSWeakSource &scene, OBSWeakSource &transition,
-		 bool &transitionOverrideOverride,
-		 std::unique_lock<std::mutex> &lock);
+		 bool &transitionOverrideOverride);
 
 /********************************************************************************
  * Main SwitcherData

--- a/src/headers/switcher-data-structs.hpp
+++ b/src/headers/switcher-data-structs.hpp
@@ -99,7 +99,7 @@ struct SwitcherData {
 
 	std::deque<SceneTransition> sceneTransitions;
 	std::deque<DefaultSceneTransition> defaultSceneTransitions;
-	bool changedDefTransitionRecently = false;
+	bool checkedDefTransition = false;
 
 	std::deque<MediaSwitch> mediaSwitches;
 
@@ -154,10 +154,12 @@ struct SwitcherData {
 	bool sceneChangedDuringWait();
 	bool prioFuncsValid();
 	void writeSceneInfoToFile();
-	void setDefaultSceneTransitions();
 	void autoStopStreamAndRecording();
 	void autoStartStreamRecording();
 	bool checkPause();
+	void checkDefaultSceneTransitions(bool &match,
+					  OBSWeakSource &transition);
+	void setCurrentDefTransition(OBSWeakSource &transition);
 	void checkSceneSequence(bool &match, OBSWeakSource &scene,
 				OBSWeakSource &transition,
 				std::unique_lock<std::mutex> &lock);

--- a/src/switch-transitions.cpp
+++ b/src/switch-transitions.cpp
@@ -143,9 +143,10 @@ void AdvSceneSwitcher::on_defaultTransitionsDown_clicked()
 		  switcher->defaultSceneTransitions[index + 1]);
 }
 
-void SwitcherData::setDefaultSceneTransitions()
+void SwitcherData::checkDefaultSceneTransitions(bool &match,
+						OBSWeakSource &transition)
 {
-	if (changedDefTransitionRecently)
+	if (checkedDefTransition)
 		return;
 
 	obs_source_t *currentSource = obs_frontend_get_current_scene();
@@ -156,22 +157,25 @@ void SwitcherData::setDefaultSceneTransitions()
 			if (!s.initialized())
 				continue;
 
-			obs_source_t *transition =
-				obs_weak_source_get_source(s.transition);
-			//This might cancel the current transition
-			//There is no way to be sure when the previous transition finished
-			obs_frontend_set_current_transition(transition);
+			match = true;
+			transition = s.transition;
 
 			if (verbose)
 				s.logMatch();
-
-			obs_source_release(transition);
 			break;
 		}
 	}
 	obs_source_release(currentSource);
 	obs_weak_source_release(ws);
-	changedDefTransitionRecently = true;
+
+	checkedDefTransition = true;
+}
+
+void SwitcherData::setCurrentDefTransition(OBSWeakSource &transition)
+{
+	obs_source_t *transitionSource = obs_weak_source_get_source(transition);
+	obs_frontend_set_current_transition(transitionSource);
+	obs_source_release(transitionSource);
 }
 
 void AdvSceneSwitcher::on_transitionOverridecheckBox_stateChanged(int state)


### PR DESCRIPTION
A deadlock could occur if save callback is called during frontend set functions
(e.g. if start recording is called just before using the above
functions, as this apparently triggers a save() call)
Thus unlock() is necessary before setting current scene or transtition