### PR TITLE
Add a log when auto stopping stream / record

### DIFF
--- a/src/general.cpp
+++ b/src/general.cpp
@@ -158,10 +158,14 @@ void SwitcherData::autoStopStreamAndRecording()
 	obs_weak_source_t *ws = obs_source_get_weak_source(currentSource);
 
 	if (ws && autoStopScene == ws) {
-		if (obs_frontend_streaming_active())
+		if (obs_frontend_streaming_active()) {
+			blog(LOG_INFO, "Stopping stream because scene '%s' is active", obs_source_get_name(currentSource));
 			obs_frontend_streaming_stop();
-		if (obs_frontend_recording_active())
+		}
+		if (obs_frontend_recording_active()) {
+			blog(LOG_INFO, "Stopping record because scene '%s' is active", obs_source_get_name(currentSource));
 			obs_frontend_recording_stop();
+		}
 	}
 	obs_source_release(currentSource);
 	obs_weak_source_release(ws);
@@ -226,12 +230,16 @@ void SwitcherData::autoStartStreamRecording()
 	if (ws && autoStartScene == ws) {
 		if ((switcher->autoStartType == STREAMING ||
 		     switcher->autoStartType == RECORINDGSTREAMING) &&
-		    !obs_frontend_streaming_active())
+		    !obs_frontend_streaming_active()) {
+			blog(LOG_INFO, "Starting stream because scene '%s' is active", obs_source_get_name(currentSource));
 			obs_frontend_streaming_start();
+		}
 		if ((switcher->autoStartType == RECORDING ||
 		     switcher->autoStartType == RECORINDGSTREAMING) &&
-		    !obs_frontend_recording_active())
+		    !obs_frontend_recording_active()) {
+			blog(LOG_INFO, "Starting record because scene '%s' is active", obs_source_get_name(currentSource));
 			obs_frontend_recording_start();
+		}
 	}
 	obs_source_release(currentSource);
 	obs_weak_source_release(ws);

--- a/src/general.cpp
+++ b/src/general.cpp
@@ -159,11 +159,15 @@ void SwitcherData::autoStopStreamAndRecording()
 
 	if (ws && autoStopScene == ws) {
 		if (obs_frontend_streaming_active()) {
-			blog(LOG_INFO, "Stopping stream because scene '%s' is active", obs_source_get_name(currentSource));
+			blog(LOG_INFO,
+			     "Stopping stream because scene '%s' is active",
+			     obs_source_get_name(currentSource));
 			obs_frontend_streaming_stop();
 		}
 		if (obs_frontend_recording_active()) {
-			blog(LOG_INFO, "Stopping record because scene '%s' is active", obs_source_get_name(currentSource));
+			blog(LOG_INFO,
+			     "Stopping record because scene '%s' is active",
+			     obs_source_get_name(currentSource));
 			obs_frontend_recording_stop();
 		}
 	}
@@ -231,13 +235,17 @@ void SwitcherData::autoStartStreamRecording()
 		if ((switcher->autoStartType == STREAMING ||
 		     switcher->autoStartType == RECORINDGSTREAMING) &&
 		    !obs_frontend_streaming_active()) {
-			blog(LOG_INFO, "Starting stream because scene '%s' is active", obs_source_get_name(currentSource));
+			blog(LOG_INFO,
+			     "Starting stream because scene '%s' is active",
+			     obs_source_get_name(currentSource));
 			obs_frontend_streaming_start();
 		}
 		if ((switcher->autoStartType == RECORDING ||
 		     switcher->autoStartType == RECORINDGSTREAMING) &&
 		    !obs_frontend_recording_active()) {
-			blog(LOG_INFO, "Starting record because scene '%s' is active", obs_source_get_name(currentSource));
+			blog(LOG_INFO,
+			     "Starting record because scene '%s' is active",
+			     obs_source_get_name(currentSource));
 			obs_frontend_recording_start();
 		}
 	}


### PR DESCRIPTION
I had a hard time deciphering why the stream stopped automatically for someone when using the plugin as the logs contained nothing indicating an error or an action from the plugin.
He activated the checkbox to auto stop stream when a scene is activated (which I didn't know) so the plugin was doing exactly what asked.
I think adding a log is a good idea for an action as important as stopping the stream.
I added the same for starting stream for the same reasons.