### PR TITLE
Init noMatchDelay to zero.

### DIFF
--- a/src/headers/switcher-data-structs.hpp
+++ b/src/headers/switcher-data-structs.hpp
@@ -71,7 +71,7 @@ struct SwitcherData {
 	SceneGroup *lastRandomSceneGroup;
 	OBSWeakSource nonMatchingScene;
 	NoMatch switchIfNotMatching = NO_SWITCH;
-	double noMatchDelay;
+	double noMatchDelay = 0;
 	double noMatchCount = 0;
 	StartupBehavior startupBehavior = PERSIST;
 	AutoStartEvent autoStartEvent = AutoStartEvent::NEVER;


### PR DESCRIPTION
A non-zero value might be confusing for users which set up the plugin
for the first time.