### PR TITLE
Fix rapid scene switches by random tab

### DIFF
--- a/src/advanced-scene-switcher.cpp
+++ b/src/advanced-scene-switcher.cpp
@@ -484,6 +484,7 @@ void SwitcherData::Thread()
 		}
 
 		vblog(LOG_INFO, "try to sleep for %ld", duration.count());
+		setWaitScene();
 		cv.wait_for(lock, duration);
 
 		startTime = std::chrono::high_resolution_clock::now();
@@ -510,6 +511,7 @@ void SwitcherData::Thread()
 			vblog(LOG_INFO, "sleep for %ld before switching scene",
 			      duration.count());
 
+			setWaitScene();
 			cv.wait_for(lock, duration);
 
 			if (stop) {
@@ -684,6 +686,12 @@ void SwitcherData::Stop()
 
 	server.stop();
 	client.disconnect();
+}
+
+void SwitcherData::setWaitScene()
+{
+	waitScene = obs_frontend_get_current_scene();
+	obs_source_release(waitScene);
 }
 
 bool SwitcherData::sceneChangedDuringWait()

--- a/src/headers/switcher-data-structs.hpp
+++ b/src/headers/switcher-data-structs.hpp
@@ -192,6 +192,7 @@ struct SwitcherData {
 	void Start();
 	void Stop();
 
+	void setWaitScene();
 	bool sceneChangedDuringWait();
 
 	bool prioFuncsValid();

--- a/src/switch-sequence.cpp
+++ b/src/switch-sequence.cpp
@@ -440,8 +440,6 @@ void SceneSequenceSwitch::prepareUninterruptibleMatch(
 {
 	int dur = delay.seconds * 1000;
 	if (dur > 0) {
-		switcher->waitScene = obs_weak_source_get_source(currentScene);
-		obs_source_release(switcher->waitScene);
 		linger = dur;
 	}
 }


### PR DESCRIPTION
Wait scene was not set while waiting for scene changes on the random
tab.
If wait scene was ever set by other means (sequence) the scene switcher
would immediately wake up as the wait scene is not the expected value.