### PR TITLE
Run condition check for paused macros

### DIFF
--- a/src/macro.cpp
+++ b/src/macro.cpp
@@ -20,10 +20,6 @@ Macro::~Macro() {}
 
 bool Macro::CeckMatch()
 {
-	if (_paused) {
-		vblog(LOG_INFO, "Macro %s is paused", _name.c_str());
-		return false;
-	}
 	_matched = false;
 	for (auto &c : _conditions) {
 		bool cond = c->CheckCondition();
@@ -64,6 +60,18 @@ bool Macro::CeckMatch()
 	}
 
 	vblog(LOG_INFO, "Macro %s returned %d", _name.c_str(), _matched);
+
+	// Condition checks shall still be run even if macro is paused.
+	// Otherwise conditions might behave in unexpected ways when resuming.
+	//
+	// For example, audio could immediately match after unpause, when it
+	// matched before it was paused due to timers not being updated.
+	if (_paused) {
+		vblog(LOG_INFO, "Macro %s is paused", _name.c_str());
+		_matched = false;
+		return false;
+	}
+
 	return _matched;
 }
 


### PR DESCRIPTION
Otherwise conditions might behave in unexpected ways when resuming.
For example, audio could immediately match after unpause, when it
matched before it was paused due to timers not being updated.