### PR TITLE
Fix Macro slots not being connected properly

### DIFF
--- a/src/headers/macro-action-edit.hpp
+++ b/src/headers/macro-action-edit.hpp
@@ -46,6 +46,13 @@ public:
 private slots:
 	void ActionSelectionChanged(const QString &text);
 	void HeaderInfoChanged(const QString &);
+signals:
+	void MacroAdded(const QString &name);
+	void MacroRemoved(const QString &name);
+	void MacroRenamed(const QString &oldName, const QString newName);
+	void SceneGroupAdded(const QString &name);
+	void SceneGroupRemoved(const QString &name);
+	void SceneGroupRenamed(const QString &oldName, const QString newName);
 
 protected:
 	QComboBox *_actionSelection;

--- a/src/headers/macro-condition-edit.hpp
+++ b/src/headers/macro-condition-edit.hpp
@@ -52,6 +52,13 @@ private slots:
 	void DurationConditionChanged(DurationCondition cond);
 	void DurationUnitChanged(DurationUnit unit);
 	void HeaderInfoChanged(const QString &);
+signals:
+	void MacroAdded(const QString &name);
+	void MacroRemoved(const QString &name);
+	void MacroRenamed(const QString &oldName, const QString newName);
+	void SceneGroupAdded(const QString &name);
+	void SceneGroupRemoved(const QString &name);
+	void SceneGroupRenamed(const QString &oldName, const QString newName);
 
 protected:
 	QComboBox *_logicSelection;

--- a/src/macro-action-edit.cpp
+++ b/src/macro-action-edit.cpp
@@ -69,6 +69,22 @@ MacroActionEdit::MacroActionEdit(QWidget *parent,
 	QWidget::connect(_actionSelection,
 			 SIGNAL(currentTextChanged(const QString &)), this,
 			 SLOT(ActionSelectionChanged(const QString &)));
+	QWidget::connect(parent, SIGNAL(MacroAdded(const QString &)), this,
+			 SIGNAL(MacroAdded(const QString &)));
+	QWidget::connect(parent, SIGNAL(MacroRemoved(const QString &)), this,
+			 SIGNAL(MacroRemoved(const QString &)));
+	QWidget::connect(parent,
+			 SIGNAL(MacroRenamed(const QString &, const QString)),
+			 this,
+			 SIGNAL(MacroRenamed(const QString &, const QString)));
+	QWidget::connect(parent, SIGNAL(SceneGroupAdded(const QString &)), this,
+			 SIGNAL(SceneGroupAdded(const QString &)));
+	QWidget::connect(parent, SIGNAL(SceneGroupRemoved(const QString &)),
+			 this, SIGNAL(SceneGroupRemoved(const QString &)));
+	QWidget::connect(
+		parent,
+		SIGNAL(SceneGroupRenamed(const QString &, const QString)), this,
+		SIGNAL(SceneGroupRenamed(const QString &, const QString)));
 
 	populateActionSelection(_actionSelection);
 

--- a/src/macro-condition-edit.cpp
+++ b/src/macro-condition-edit.cpp
@@ -108,6 +108,22 @@ MacroConditionEdit::MacroConditionEdit(
 	QWidget::connect(_dur, SIGNAL(ConditionChanged(DurationCondition)),
 			 this,
 			 SLOT(DurationConditionChanged(DurationCondition)));
+	QWidget::connect(parent, SIGNAL(MacroAdded(const QString &)), this,
+			 SIGNAL(MacroAdded(const QString &)));
+	QWidget::connect(parent, SIGNAL(MacroRemoved(const QString &)), this,
+			 SIGNAL(MacroRemoved(const QString &)));
+	QWidget::connect(parent,
+			 SIGNAL(MacroRenamed(const QString &, const QString)),
+			 this,
+			 SIGNAL(MacroRenamed(const QString &, const QString)));
+	QWidget::connect(parent, SIGNAL(SceneGroupAdded(const QString &)), this,
+			 SIGNAL(SceneGroupAdded(const QString &)));
+	QWidget::connect(parent, SIGNAL(SceneGroupRemoved(const QString &)),
+			 this, SIGNAL(SceneGroupRemoved(const QString &)));
+	QWidget::connect(
+		parent,
+		SIGNAL(SceneGroupRenamed(const QString &, const QString)), this,
+		SIGNAL(SceneGroupRenamed(const QString &, const QString)));
 
 	populateLogicSelection(_logicSelection, root);
 	populateConditionSelection(_conditionSelection);


### PR DESCRIPTION
Problem was introduced when adding header info.

To avoid the issue in future forward signals of the main plugin window
via condition and action edit widgets instead of relying on parent()
being the main window.