### PR TITLE
Add note to network tab

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -457,6 +457,7 @@ AdvSceneSwitcher.videoTab.help="<html><head/><body><p>This tab will allow you to
 
 ; Network Tab
 AdvSceneSwitcher.networkTab.title="Network"
+AdvSceneSwitcher.networkTab.description="This tab will allow you to remotely control the active scene of another OBS instance.\nPlease note that the scene names have to match exactly on all OBS instances."
 AdvSceneSwitcher.networkTab.warning="Running the server outside of a local network will allow third parties to read the active scene."
 AdvSceneSwitcher.networkTab.DisabledWarning="This functionality unfortunately had to be disabled on macOS due to library incompatibilities when running the obs-websocket plugin in parallel."
 AdvSceneSwitcher.networkTab.server="Start server (Sends scene switch messages to all connected clients)"

--- a/forms/advanced-scene-switcher.ui
+++ b/forms/advanced-scene-switcher.ui
@@ -3717,6 +3717,13 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_30">
        <item>
+        <widget class="QLabel" name="networkTabDescription">
+         <property name="text">
+          <string>AdvSceneSwitcher.networkTab.description</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QLabel" name="networkTabWarningLabel">
          <property name="text">
           <string>AdvSceneSwitcher.networkTab.warning</string>


### PR DESCRIPTION
The requirement of the scene names having to match extactly was not made
clear and caused some confusion.