### PR TITLE
Fix macro video condition save

### DIFF
--- a/src/macro-condition-video.cpp
+++ b/src/macro-condition-video.cpp
@@ -64,6 +64,7 @@ bool MacroConditionVideo::Save(obs_data_t *obj)
 
 bool MacroConditionVideo::Load(obs_data_t *obj)
 {
+	MacroCondition::Load(obj);
 	const char *videoSourceName = obs_data_get_string(obj, "videoSource");
 	_videoSource = GetWeakSourceByName(videoSourceName);
 	_condition =


### PR DESCRIPTION
Logic, collapsed state and time constraint were not saved for video
condition.