### PR TITLE
Do not apply MouseWheelWidgetAdjustmentGuard to QScrollBars

### DIFF
--- a/src/macro-segment.cpp
+++ b/src/macro-segment.cpp
@@ -5,6 +5,7 @@
 #include <obs.hpp>
 #include <QEvent>
 #include <QLabel>
+#include <QScrollBar>
 
 bool MacroSegment::Save(obs_data_t *obj)
 {
@@ -136,6 +137,11 @@ void MacroSegmentEdit::SetFocusPolicyOfWidgets()
 	QList<QWidget *> widgets = this->findChildren<QWidget *>();
 	for (auto w : widgets) {
 		w->setFocusPolicy(Qt::StrongFocus);
+		// Ignore QScrollBar as there is no danger of accidentally modifying anything
+		// and long expanded QComboBox would be difficult to interact with otherwise.
+		if (qobject_cast<QScrollBar *>(w)) {
+			continue;
+		}
 		w->installEventFilter(new MouseWheelWidgetAdjustmentGuard(w));
 	}
 }


### PR DESCRIPTION
Without this change, it will be annoying to interact with expanded
QComboBoxes and there should be no danger of accidentally modifying
macro settings by interacting with QScrollBars