### PR TITLE
Draft separating dependencies to their own libs

### DIFF
--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -4,46 +4,45 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: 'recursive'
-    - name: check_libobs_revision
-      run: |
-           sudo apt update
-           sudo apt install libobs-dev
-           mkdir source
-           cd source
-           dpkg -l libobs-dev | tr -s " "| grep libobs | cut -d" " -f3 > libobs.rev
-    - name: install_frontend_header
-      run: |
-           [ -e /usr/include/obs/obs-frontend-api.h ] && { echo "ERROR: obs-frontend-api.h already in system. Maybe the package libobs-dev is installing it."; exit 1; }
-           cd source
-           LIBOBSREV=$(cat libobs.rev)
-           sudo apt update
-           sudo apt install devscripts
-           dget -u http://archive.ubuntu.com/ubuntu/pool/universe/o/obs-studio/obs-studio_$LIBOBSREV.dsc
-           cd ..
-           sudo find -name obs-frontend-api.h -exec cp {} /usr/include/obs/ \;
-           egrep '#include <obs.h>' /usr/include/obs/obs-frontend-api.h || { echo "ERROR: check if the sed commands are needed from now."; exit 1; }
-           sudo sed -i 's/#include <obs.h>/#include <obs\/obs.h>/' /usr/include/obs/obs-frontend-api.h
-           sudo sed -i 's/#include <util\/darray.h>/#include <obs\/util\/darray.h>/' /usr/include/obs/obs-frontend-api.h
-    - name: create_tarball
-      run: |
-           cd ..
-           tar --exclude=.git -cvzf obs-scene-switcher_0.1+testonly.orig.tar.gz SceneSwitcher
-    - name: create_debian_dir
-      run: |
-           cp -a CI/linux/debian .
-    - name: install_dependencies
-      run: |
-           # devscripts and libobs-dev are needed but they were already installed
-           # from check_libobs_revision and install_frontend_header sections.
-           sudo apt update
-           sudo apt install cmake debhelper libcurl4-openssl-dev libxss-dev libxtst-dev qtbase5-dev libopencv-dev libprocps-dev
-    - name: build
-      run: |
-           debuild --no-lintian --no-sign
+      - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+      - name: check_libobs_revision
+        run: |
+          sudo apt update
+          sudo apt install libobs-dev
+          mkdir source
+          cd source
+          dpkg -l libobs-dev | tr -s " "| grep libobs | cut -d" " -f3 > libobs.rev
+      - name: install_frontend_header
+        run: |
+          [ -e /usr/include/obs/obs-frontend-api.h ] && { echo "ERROR: obs-frontend-api.h already in system. Maybe the package libobs-dev is installing it."; exit 1; }
+          cd source
+          LIBOBSREV=$(cat libobs.rev)
+          sudo apt update
+          sudo apt install devscripts
+          dget -u http://archive.ubuntu.com/ubuntu/pool/universe/o/obs-studio/obs-studio_$LIBOBSREV.dsc
+          cd ..
+          sudo find -name obs-frontend-api.h -exec cp {} /usr/include/obs/ \;
+          egrep '#include <obs.h>' /usr/include/obs/obs-frontend-api.h || { echo "ERROR: check if the sed commands are needed from now."; exit 1; }
+          sudo sed -i 's/#include <obs.h>/#include <obs\/obs.h>/' /usr/include/obs/obs-frontend-api.h
+          sudo sed -i 's/#include <util\/darray.h>/#include <obs\/util\/darray.h>/' /usr/include/obs/obs-frontend-api.h
+      - name: create_tarball
+        run: |
+          cd ..
+          tar --exclude=.git -cvzf obs-scene-switcher_0.1+testonly.orig.tar.gz SceneSwitcher
+      - name: create_debian_dir
+        run: |
+          cp -a CI/linux/debian .
+      - name: install_dependencies
+        run: |
+          # devscripts and libobs-dev are needed but they were already installed
+          # from check_libobs_revision and install_frontend_header sections.
+          sudo apt update
+          sudo apt install cmake debhelper libcurl4-openssl-dev libxss-dev libxtst-dev qtbase5-dev libopencv-dev libprocps-dev
+      - name: build
+        run: |
+          debuild --no-lintian --no-sign

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,25 +12,25 @@ jobs:
     name: "macOS 64-bit"
     runs-on: [macos-latest]
     env:
-      QT_VERSION: '5.15.2'
-      MACOS_DEPS_VERSION: '2020-12-11'
+      QT_VERSION: "5.15.2"
+      MACOS_DEPS_VERSION: "2020-12-11"
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
         with:
           repository: obsproject/obs-studio
-          submodules: 'recursive'
-          ref: 'refs/tags/${{ env.OBS_TAG }}'
+          submodules: "recursive"
+          ref: "refs/tags/${{ env.OBS_TAG }}"
       - name: "Checkout plugin"
         uses: actions/checkout@v2.3.4
         with:
           path: UI/frontend-plugins/${{ env.PLUGIN_NAME }}
-          submodules: 'recursive'
+          submodules: "recursive"
       - name: Fetch Git Tags
         run: |
           cd UI/frontend-plugins/${{ env.PLUGIN_NAME }}
           git fetch --prune --tags --unshallow
-      - name: 'Install prerequisites (Homebrew)'
+      - name: "Install prerequisites (Homebrew)"
         shell: bash
         run: |
           if [ -d /usr/local/opt/openssl@1.0.2t ]; then
@@ -42,20 +42,20 @@ jobs:
               brew untap local/python2
           fi
           brew bundle --file ./CI/scripts/macos/Brewfile
-      - name: 'Install prerequisite: Pre-built dependencies'
+      - name: "Install prerequisite: Pre-built dependencies"
         if: steps.deps-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
           curl -L -O https://github.com/obsproject/obs-deps/releases/download/${{ env.MACOS_DEPS_VERSION }}/macos-deps-${{ env.MACOS_DEPS_VERSION }}.tar.gz
           tar -xf ./macos-deps-${{ env.MACOS_DEPS_VERSION }}.tar.gz -C "/tmp"
-      - name: 'Install prerequisite: Pre-built dependency Qt'
+      - name: "Install prerequisite: Pre-built dependency Qt"
         if: steps.deps-qt-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
           curl -L -O https://github.com/obsproject/obs-deps/releases/download/${{ env.MACOS_DEPS_VERSION }}/macos-qt-${{ env.QT_VERSION }}-${{ env.MACOS_DEPS_VERSION }}.tar.gz
           tar -xf ./macos-qt-${{ env.QT_VERSION }}-${{ env.MACOS_DEPS_VERSION }}.tar.gz -C "/tmp"
           xattr -r -d com.apple.quarantine /tmp/obsdeps
-      - name: 'Build prerequisite: OpenCV'
+      - name: "Build prerequisite: OpenCV"
         shell: bash
         run: |
           cd UI/frontend-plugins/${{ env.PLUGIN_NAME }}/deps/opencv
@@ -79,7 +79,7 @@ jobs:
           cd ./build
           make -j4
           cd -
-      - name: 'Install prerequisite: Packages app'
+      - name: "Install prerequisite: Packages app"
         if: success()
         shell: bash
         run: |
@@ -90,12 +90,16 @@ jobs:
         if: success()
         shell: bash
         run: |
+          fix_linker_paths() {
+            install_name_tool -change @rpath/libobs-frontend-api.dylib @executable_path/../Frameworks/libobs-frontend-api.dylib $1
+            install_name_tool -change @rpath/libobs.0.dylib @executable_path/../Frameworks/libobs.0.dylib $1
+            install_name_tool -change /tmp/obsdeps/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets $1
+            install_name_tool -change /tmp/obsdeps/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui $1
+            install_name_tool -change /tmp/obsdeps/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore $1
+          }
           cd UI/frontend-plugins/${{ env.PLUGIN_NAME }}
-          install_name_tool -change @rpath/libobs-frontend-api.dylib @executable_path/../Frameworks/libobs-frontend-api.dylib ../../../build/UI/frontend-plugins/SceneSwitcher/advanced-scene-switcher.so
-          install_name_tool -change @rpath/libobs.0.dylib @executable_path/../Frameworks/libobs.0.dylib ../../../build/UI/frontend-plugins/SceneSwitcher/advanced-scene-switcher.so
-          install_name_tool -change /tmp/obsdeps/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets ../../../build/UI/frontend-plugins/SceneSwitcher/advanced-scene-switcher.so
-          install_name_tool -change /tmp/obsdeps/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui ../../../build/UI/frontend-plugins/SceneSwitcher/advanced-scene-switcher.so
-          install_name_tool -change /tmp/obsdeps/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ../../../build/UI/frontend-plugins/SceneSwitcher/advanced-scene-switcher.so
+          fix_linker_paths ../../../build/UI/frontend-plugins/SceneSwitcher/advanced-scene-switcher.so
+          fix_linker_paths ../../../build/UI/frontend-plugins/SceneSwitcher/src/external-macro-modules/opencv/advanced-scene-switcher-opencv.so
           FILE_DATE=$(date +%Y-%m-%d)
           FILE_NAME=${{ env.PLUGIN_NAME }}-$FILE_DATE-${{ github.sha }}-macos.pkg
           echo "FILE_NAME=${FILE_NAME}" >> $GITHUB_ENV
@@ -107,23 +111,23 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v2.2.1
         with:
-          name: '${{ env.FILE_NAME }}'
+          name: "${{ env.FILE_NAME }}"
           path: ./nightly/*.pkg
   ubuntu64:
-    name: 'Linux/Ubuntu 64-bit'
+    name: "Linux/Ubuntu 64-bit"
     runs-on: [ubuntu-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
         with:
           repository: obsproject/obs-studio
-          submodules: 'recursive'
-          ref: 'refs/tags/${{ env.OBS_TAG }}'
+          submodules: "recursive"
+          ref: "refs/tags/${{ env.OBS_TAG }}"
       - name: "Checkout plugin"
         uses: actions/checkout@v2.3.4
         with:
           path: UI/frontend-plugins/${{ env.PLUGIN_NAME }}
-          submodules: 'recursive'
+          submodules: "recursive"
       - name: Add plugin to obs cmake
         shell: bash
         run: echo "add_subdirectory(${{ env.PLUGIN_NAME }})" >> UI/frontend-plugins/CMakeLists.txt
@@ -181,17 +185,17 @@ jobs:
            libxcb-xfixes0-dev \
            libopencv-dev \
            libprocps-dev
-      - name: 'Configure'
+      - name: "Configure"
         shell: bash
         run: |
           mkdir ./build
           cd ./build
           cmake -DENABLE_PIPEWIRE=OFF -DUNIX_STRUCTURE=0 -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/obs-studio-portable" -DWITH_RTMPS=OFF -DBUILD_BROWSER=OFF ..
-      - name: 'Build'
+      - name: "Build"
         shell: bash
         working-directory: ${{ github.workspace }}/build
         run: make -j4
-      - name: 'Package'
+      - name: "Package"
         shell: bash
         run: |
           FILE_DATE=$(date +%Y-%m-%d)
@@ -201,12 +205,15 @@ jobs:
           strip -d ./build/UI/frontend-plugins/${{ env.PLUGIN_NAME }}/${{ env.LIB_NAME }}.so
           mv ./build/UI/frontend-plugins/${{ env.PLUGIN_NAME }}/${{ env.LIB_NAME }}.so ./${{ env.LIB_NAME }}/bin/64bit/${{ env.LIB_NAME }}.so
           mv ./UI/frontend-plugins/${{ env.PLUGIN_NAME }}/data ./${{ env.LIB_NAME }}/data
+          # Macro modules
+          strip -d ./build/UI/frontend-plugins/${{ env.PLUGIN_NAME }}/src/external-macro-modules/opencv/advanced-scene-switcher-opencv.so
+          mv ./build/UI/frontend-plugins/${{ env.PLUGIN_NAME }}/src/external-macro-modules/opencv/advanced-scene-switcher-opencv.so ./${{ env.LIB_NAME }}/bin/64bit/
           tar -cvzf "${FILE_NAME}" ${{ env.LIB_NAME }}
-      - name: 'Publish'
+      - name: "Publish"
         uses: actions/upload-artifact@v2.2.1
         with:
-          name: '${{ env.FILE_NAME }}'
-          path: '*.tar.gz'
+          name: "${{ env.FILE_NAME }}"
+          path: "*.tar.gz"
   windows:
     name: Windows
     runs-on: [windows-latest]
@@ -217,7 +224,7 @@ jobs:
       QT_VERSION: 5.10.1
       CMAKE_GENERATOR: "Visual Studio 16 2019"
       CMAKE_SYSTEM_VERSION: "10.0.18363.657"
-      WINDOWS_DEPS_VERSION: '2019'
+      WINDOWS_DEPS_VERSION: "2019"
     steps:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
@@ -225,27 +232,27 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           repository: obsproject/obs-studio
-          submodules: 'recursive'
-          ref: 'refs/tags/${{ env.OBS_TAG }}'
+          submodules: "recursive"
+          ref: "refs/tags/${{ env.OBS_TAG }}"
       - name: Checkout plugin
         uses: actions/checkout@v2.3.4
         with:
           path: UI/frontend-plugins/${{ env.PLUGIN_NAME}}
-          submodules: 'recursive'
+          submodules: "recursive"
       - name: Add plugin to obs cmake
         shell: cmd
         run: echo add_subdirectory(${{ env.PLUGIN_NAME }}) >> UI/frontend-plugins/CMakeLists.txt
       - name: Fetch Git Tags
         run: git fetch --prune --tags --unshallow
-      - name: 'Install prerequisite: QT'
+      - name: "Install prerequisite: QT"
         run: |
           curl -kLO https://cdn-fastly.obsproject.com/downloads/Qt_${{ env.QT_VERSION }}.7z -f --retry 5 -C -
           7z x Qt_${{ env.QT_VERSION }}.7z -o"${{ github.workspace }}/cmbuild/QT"
-      - name: 'Install prerequisite: Pre-built dependencies'
+      - name: "Install prerequisite: Pre-built dependencies"
         run: |
           curl -kLO https://cdn-fastly.obsproject.com/downloads/dependencies${{ env.WINDOWS_DEPS_VERSION }}.zip -f --retry 5 -C -
           7z x dependencies${{ env.WINDOWS_DEPS_VERSION }}.zip -o"${{ github.workspace }}/cmbuild/deps"
-      - name: 'Build prerequisite: OpenCV'
+      - name: "Build prerequisite: OpenCV"
         run: |
           cd UI/frontend-plugins/${{ env.PLUGIN_NAME }}/deps/opencv
           mkdir build
@@ -283,7 +290,7 @@ jobs:
           $env:FILE_DATE=(Get-Date -UFormat "%F")
           $env:FILE_NAME="${{ env.PLUGIN_NAME }}-${env:FILE_DATE}-${{ github.sha }}-windows"
           echo "FILE_NAME=${env:FILE_NAME}" >> ${env:GITHUB_ENV}
-          robocopy .\build${{ matrix.arch }}\rundir\RelWithDebInfo\obs-plugins\${{ matrix.arch }}bit\ .\package\obs-plugins\${{ matrix.arch }}bit ${{ env.LIB_NAME }}.* /E /XF .gitignore
+          robocopy .\build${{ matrix.arch }}\rundir\RelWithDebInfo\obs-plugins\${{ matrix.arch }}bit\ .\package\obs-plugins\${{ matrix.arch }}bit ${{ env.LIB_NAME }}* /E /XF .gitignore
           robocopy .\build${{ matrix.arch }}\rundir\RelWithDebInfo\data\obs-plugins\${{ env.LIB_NAME }}\ .\package\data\obs-plugins\${{ env.LIB_NAME }}\ /E /XF .gitignore
           cp UI/frontend-plugins/${{ env.PLUGIN_NAME }}/deps/opencv/build/bin/Release/*dll package/obs-plugins/${{ matrix.arch }}bit
           exit 0
@@ -291,11 +298,11 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v2.2.1
         with:
-          name: '${{ env.FILE_NAME }}-${{ matrix.arch }}bit'
+          name: "${{ env.FILE_NAME }}-${{ matrix.arch }}bit"
           path: package/*
   windows-installer:
     needs: [windows]
-    name: 'Create Windows Installer'
+    name: "Create Windows Installer"
     runs-on: [windows-latest]
     steps:
       - name: "Checkout plugin"
@@ -332,12 +339,12 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v2.2.0
         with:
-          name: '${{ env.FILE_NAME }}-installer'
+          name: "${{ env.FILE_NAME }}-installer"
           path: build/CI/windows/Output/*.exe
   release:
     needs: [macos64, ubuntu64, windows, windows-installer]
-    name: 'Create Release'
-    runs-on: [ubuntu-18.04]
+    name: "Create Release"
+    runs-on: [ubuntu-latest]
     steps:
       - name: "Checkout plugin"
         uses: actions/checkout@v2.3.4
@@ -347,7 +354,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: artifacts
-      - name: 'Package'
+      - name: "Package"
         shell: bash
         run: |
           mkdir -p ${{ env.PLUGIN_NAME }}/Linux ${{ env.PLUGIN_NAME }}/MacOs ${{ env.PLUGIN_NAME }}/Windows
@@ -366,4 +373,4 @@ jobs:
         uses: actions/upload-artifact@v2.2.1
         with:
           name: "Release"
-          path: '*.zip'
+          path: "*.zip"

--- a/CI/macos/SceneSwitcher.pkgproj
+++ b/CI/macos/SceneSwitcher.pkgproj
@@ -52,6 +52,22 @@
 																		<key>GID</key>
 																		<integer>80</integer>
 																		<key>PATH</key>
+																		<string>../../../../../build/UI/frontend-plugins/SceneSwitcher/src/external-macro-modules/opencv/advanced-scene-switcher-opencv.so</string>
+																		<key>PATH_TYPE</key>
+																		<integer>3</integer>
+																		<key>PERMISSIONS</key>
+																		<integer>493</integer>
+																		<key>TYPE</key>
+																		<integer>3</integer>
+																		<key>UID</key>
+																		<integer>0</integer>
+																	</dict>
+																	<dict>
+																		<key>CHILDREN</key>
+																		<array/>
+																		<key>GID</key>
+																		<integer>80</integer>
+																		<key>PATH</key>
 																		<string>../../deps/opencv/build/lib/libopencv_objdetect.4.5.3.dylib</string>
 																		<key>PATH_TYPE</key>
 																		<integer>3</integer>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 # Compiler settings
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 if(CMAKE_COMPILER_IS_GNUCC
    OR CMAKE_COMPILER_IS_GNUCXX
@@ -110,6 +111,7 @@ endif()
 
 # Platform specific settings
 if(APPLE)
+  set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
   find_library(COCOA Cocoa)
   if(BUILD_OUT_OF_TREE)
     find_package(Qt5MacExtras REQUIRED)
@@ -239,7 +241,6 @@ set(advanced-scene-switcher_HEADERS
     src/headers/macro-condition-studio-mode.hpp
     src/headers/macro-condition-timer.hpp
     src/headers/macro-condition-transition.hpp
-    src/headers/macro-condition-video.hpp
     src/headers/macro-condition-virtual-cam.hpp
     src/headers/macro-condition-window.hpp
     src/headers/macro.hpp
@@ -339,7 +340,6 @@ set(advanced-scene-switcher_SOURCES
     src/macro-condition-studio-mode.cpp
     src/macro-condition-timer.cpp
     src/macro-condition-transition.cpp
-    src/macro-condition-video.cpp
     src/macro-condition-virtual-cam.cpp
     src/macro-condition-window.cpp
     src/macro.cpp
@@ -359,22 +359,6 @@ set(advanced-scene-switcher_SOURCES
     src/utility.cpp
     src/volume-control.cpp
     src/version.cpp)
-
-# opencv
-find_package(OpenCV)
-if(OpenCV_FOUND)
-  include_directories("${OpenCV_INCLUDE_DIRS}")
-else()
-  set(OpenCV_LIBRARIES "")
-  message(
-    WARNING
-      "OpenCV not found! Functionality relying on OpenCV will be disabled!\nOpenCV sources are available under: ${CMAKE_CURRENT_SOURCE_DIR}/deps/opencv"
-  )
-  list(REMOVE_ITEM advanced-scene-switcher_SOURCES
-       src/macro-condition-video.cpp)
-  list(REMOVE_ITEM advanced-scene-switcher_HEADERS
-       src/headers/macro-condition-video.hpp)
-endif()
 
 # Backwards compatability checks with older OBS versions
 if(DEFINED LibObs_VERSION_MAJOR)
@@ -401,7 +385,7 @@ if(DEFINED LibObs_VERSION_MAJOR)
 endif()
 
 add_library(
-  advanced-scene-switcher MODULE
+  advanced-scene-switcher SHARED
   ${advanced-scene-switcher_HEADERS}
   ${advanced-scene-switcher_SOURCES}
   ${advanced-scene-switcher_UI_HEADERS}
@@ -413,7 +397,6 @@ if(BUILD_OUT_OF_TREE)
   target_link_libraries(
     advanced-scene-switcher
     ${advanced-scene-switcher_PLATFORM_LIBS}
-    ${OpenCV_LIBRARIES}
     ${LIBOBS_LIB}
     ${LIBOBS_FRONTEND_API_LIB}
     Qt5::Core
@@ -448,6 +431,8 @@ else()
   # In tree build
   target_link_libraries(
     advanced-scene-switcher ${advanced-scene-switcher_PLATFORM_LIBS}
-    ${OpenCV_LIBRARIES} obs-frontend-api Qt5::Widgets libobs)
+    obs-frontend-api Qt5::Widgets libobs)
   install_obs_plugin_with_data(advanced-scene-switcher data)
 endif()
+
+add_subdirectory(src/external-macro-modules)

--- a/src/external-macro-modules/CMakeLists.txt
+++ b/src/external-macro-modules/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Add macro conditions or actions which have dependencies to external libraries
+# or other components which might potentially not be fulfilled by the user and
+# thus cause issues.
+add_subdirectory(opencv)

--- a/src/external-macro-modules/opencv/CMakeLists.txt
+++ b/src/external-macro-modules/opencv/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.14)
+project(advanced-scene-switcher-opencv)
+
+add_definitions(-DADVSS_MODULE)
+
+find_package(OpenCV)
+if(OpenCV_FOUND)
+  include_directories("${OpenCV_INCLUDE_DIRS}")
+else()
+  set(OpenCV_LIBRARIES "")
+  message(
+    FATAL
+    "OpenCV not found! Functionality relying on OpenCV will be disabled!\nOpenCV sources are available under: ${CMAKE_CURRENT_SOURCE_DIR}/deps/opencv"
+  )
+endif()
+
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../../headers")
+set(module_SOURCES macro-condition-video.cpp macro-condition-video.hpp)
+add_library(advanced-scene-switcher-opencv MODULE ${module_SOURCES})
+
+if(BUILD_OUT_OF_TREE)
+  target_link_libraries(
+    advanced-scene-switcher-opencv
+    advanced-scene-switcher
+    ${LIBOBS_LIB}
+    ${LIBOBS_FRONTEND_API_LIB}
+    ${OpenCV_LIBRARIES}
+    Qt5::Core
+    Qt5::Widgets)
+
+  if(UNIX AND NOT APPLE)
+    if(NOT LIB_OUT_DIR)
+      set(LIB_OUT_DIR "/lib/obs-plugins")
+    endif()
+    set_target_properties(advanced-scene-switcher-opencv PROPERTIES PREFIX "")
+    install(TARGETS advanced-scene-switcher-opencv
+            LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIB_OUT_DIR})
+  endif()
+else()
+  target_link_libraries(
+    advanced-scene-switcher-opencv
+    advanced-scene-switcher
+    obs-frontend-api
+    ${OpenCV_LIBRARIES}
+    Qt5::Core
+    Qt5::Widgets
+    libobs)
+  install_obs_plugin(advanced-scene-switcher-opencv)
+endif()

--- a/src/external-macro-modules/opencv/macro-condition-video.cpp
+++ b/src/external-macro-modules/opencv/macro-condition-video.cpp
@@ -1,7 +1,9 @@
-#include "headers/macro-condition-edit.hpp"
-#include "headers/macro-condition-video.hpp"
-#include "headers/utility.hpp"
-#include "headers/advanced-scene-switcher.hpp"
+#include "macro-condition-video.hpp"
+
+#include <advanced-scene-switcher.hpp>
+#include <macro-condition-edit.hpp>
+#include <switcher-data-structs.hpp>
+#include <utility.hpp>
 
 #include <QFileDialog>
 #include <QBuffer>
@@ -450,9 +452,9 @@ MacroConditionVideoEdit::MacroConditionVideoEdit(
 
 	_throttleEnable = new QCheckBox();
 	_throttleCount = new QSpinBox();
-	_throttleCount->setMinimum(1 * switcher->interval);
-	_throttleCount->setMaximum(10 * switcher->interval);
-	_throttleCount->setSingleStep(switcher->interval);
+	_throttleCount->setMinimum(1 * GetSwitcher()->interval);
+	_throttleCount->setMaximum(10 * GetSwitcher()->interval);
+	_throttleCount->setSingleStep(GetSwitcher()->interval);
 	_showMatch = new QPushButton(
 		obs_module_text("AdvSceneSwitcher.condition.video.showMatch"));
 
@@ -595,7 +597,7 @@ void MacroConditionVideoEdit::SourceChanged(const QString &text)
 		return;
 	}
 
-	std::lock_guard<std::mutex> lock(switcher->m);
+	std::lock_guard<std::mutex> lock(GetSwitcher()->m);
 	_entryData->_videoSource = GetWeakSourceByQString(text);
 	_entryData->ResetLastMatch();
 	emit HeaderInfoChanged(
@@ -608,7 +610,7 @@ void MacroConditionVideoEdit::ConditionChanged(int cond)
 		return;
 	}
 
-	std::lock_guard<std::mutex> lock(switcher->m);
+	std::lock_guard<std::mutex> lock(GetSwitcher()->m);
 	_entryData->_condition = static_cast<VideoCondition>(cond);
 	_entryData->ResetLastMatch();
 	SetWidgetVisibility();
@@ -634,7 +636,7 @@ void MacroConditionVideoEdit::ImagePathChanged(const QString &text)
 		return;
 	}
 
-	std::lock_guard<std::mutex> lock(switcher->m);
+	std::lock_guard<std::mutex> lock(GetSwitcher()->m);
 	_entryData->_file = text.toUtf8().constData();
 	_entryData->ResetLastMatch();
 	if (_entryData->LoadImageFromFile()) {
@@ -712,7 +714,7 @@ void MacroConditionVideoEdit::UsePatternForChangedCheckChanged(int value)
 		return;
 	}
 
-	std::lock_guard<std::mutex> lock(switcher->m);
+	std::lock_guard<std::mutex> lock(GetSwitcher()->m);
 	_entryData->_usePatternForChangedCheck = value;
 	_patternThreshold->setVisible(value);
 	adjustSize();
@@ -724,7 +726,7 @@ void MacroConditionVideoEdit::PatternThresholdChanged(double value)
 		return;
 	}
 
-	std::lock_guard<std::mutex> lock(switcher->m);
+	std::lock_guard<std::mutex> lock(GetSwitcher()->m);
 	_entryData->_patternThreshold = value;
 }
 
@@ -734,7 +736,7 @@ void MacroConditionVideoEdit::UseAlphaAsMaskChanged(int value)
 		return;
 	}
 
-	std::lock_guard<std::mutex> lock(switcher->m);
+	std::lock_guard<std::mutex> lock(GetSwitcher()->m);
 	_entryData->_useAlphaAsMask = value;
 	_entryData->LoadImageFromFile();
 }
@@ -745,7 +747,7 @@ void MacroConditionVideoEdit::ObjectScaleThresholdChanged(double value)
 		return;
 	}
 
-	std::lock_guard<std::mutex> lock(switcher->m);
+	std::lock_guard<std::mutex> lock(GetSwitcher()->m);
 	_entryData->_scaleFactor = value;
 }
 
@@ -755,7 +757,7 @@ void MacroConditionVideoEdit::MinNeighborsChanged(int value)
 		return;
 	}
 
-	std::lock_guard<std::mutex> lock(switcher->m);
+	std::lock_guard<std::mutex> lock(GetSwitcher()->m);
 	_entryData->_minNeighbors = value;
 }
 
@@ -765,7 +767,7 @@ void MacroConditionVideoEdit::MinSizeXChanged(int value)
 		return;
 	}
 
-	std::lock_guard<std::mutex> lock(switcher->m);
+	std::lock_guard<std::mutex> lock(GetSwitcher()->m);
 	_entryData->_minSizeX = value;
 }
 
@@ -775,7 +777,7 @@ void MacroConditionVideoEdit::MinSizeYChanged(int value)
 		return;
 	}
 
-	std::lock_guard<std::mutex> lock(switcher->m);
+	std::lock_guard<std::mutex> lock(GetSwitcher()->m);
 	_entryData->_minSizeY = value;
 }
 
@@ -785,7 +787,7 @@ void MacroConditionVideoEdit::MaxSizeXChanged(int value)
 		return;
 	}
 
-	std::lock_guard<std::mutex> lock(switcher->m);
+	std::lock_guard<std::mutex> lock(GetSwitcher()->m);
 	_entryData->_maxSizeX = value;
 }
 
@@ -795,7 +797,7 @@ void MacroConditionVideoEdit::MaxSizeYChanged(int value)
 		return;
 	}
 
-	std::lock_guard<std::mutex> lock(switcher->m);
+	std::lock_guard<std::mutex> lock(GetSwitcher()->m);
 	_entryData->_maxSizeY = value;
 }
 
@@ -805,7 +807,7 @@ void MacroConditionVideoEdit::ThrottleEnableChanged(int value)
 		return;
 	}
 
-	std::lock_guard<std::mutex> lock(switcher->m);
+	std::lock_guard<std::mutex> lock(GetSwitcher()->m);
 	_entryData->_throttleEnabled = value;
 	_throttleCount->setEnabled(value);
 }
@@ -816,8 +818,8 @@ void MacroConditionVideoEdit::ThrottleCountChanged(int value)
 		return;
 	}
 
-	std::lock_guard<std::mutex> lock(switcher->m);
-	_entryData->_throttleCount = value / switcher->interval;
+	std::lock_guard<std::mutex> lock(GetSwitcher()->m);
+	_entryData->_throttleCount = value / GetSwitcher()->interval;
 }
 
 QImage markPatterns(cv::Mat &matchResult, QImage &image, QImage &pattern)
@@ -907,7 +909,7 @@ void MacroConditionVideoEdit::ModelPathChanged(const QString &text)
 
 	bool dataLoaded = false;
 	{
-		std::lock_guard<std::mutex> lock(switcher->m);
+		std::lock_guard<std::mutex> lock(GetSwitcher()->m);
 		std::string path = text.toStdString();
 		dataLoaded = _entryData->LoadModelData(path);
 	}
@@ -1003,6 +1005,6 @@ void MacroConditionVideoEdit::UpdateEntryData()
 	_maxSizeY->setValue(_entryData->_maxSizeY);
 	_throttleEnable->setChecked(_entryData->_throttleEnabled);
 	_throttleCount->setValue(_entryData->_throttleCount *
-				 switcher->interval);
+				 GetSwitcher()->interval);
 	SetWidgetVisibility();
 }

--- a/src/external-macro-modules/opencv/macro-condition-video.hpp
+++ b/src/external-macro-modules/opencv/macro-condition-video.hpp
@@ -1,7 +1,7 @@
 #pragma once
-#include "macro.hpp"
-#include "screenshot-helper.hpp"
-#include "file-selection.hpp"
+#include <macro.hpp>
+#include <screenshot-helper.hpp>
+#include <file-selection.hpp>
 
 #include <QWidget>
 #include <QComboBox>

--- a/src/headers/advanced-scene-switcher.hpp
+++ b/src/headers/advanced-scene-switcher.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #ifdef BUILD_OUT_OF_TREE
 #include "../../forms/ui_advanced-scene-switcher.h"
+#elif defined ADVSS_MODULE
+#include "../../../ui_advanced-scene-switcher.h"
 #else
 #include "ui_advanced-scene-switcher.h"
 #endif
@@ -297,3 +299,4 @@ void AskForBackup(obs_data_t *obj);
  ******************************************************************************/
 struct SwitcherData;
 extern SwitcherData *switcher;
+SwitcherData *GetSwitcher();


### PR DESCRIPTION
Idea is to avoid issues with potentially unfulfilled dependencies.
For example the specific opencv version used for the video condition
might not be available on all linux distros or the steamvr condition
only runs on setups which include the necessary libs.