### PR TITLE
Fix dock location and size not saving correctly

### DIFF
--- a/src/advanced-scene-switcher.cpp
+++ b/src/advanced-scene-switcher.cpp
@@ -662,10 +662,7 @@ extern "C" void InitSceneSwitcher()
 	// Windows does not require the plugins to be loaded manually
 	LoadPlugins();
 #endif
-
-	dock = new StatusDock(
-		static_cast<QMainWindow *>(obs_frontend_get_main_window()));
-	obs_frontend_add_dock(dock);
+	SetupDock();
 
 	auto cb = []() {
 		if (switcher->settingsWindowOpened) {

--- a/src/general.cpp
+++ b/src/general.cpp
@@ -456,7 +456,6 @@ void SwitcherData::loadSettings(obs_data_t *obj)
 	loadSceneTriggers(obj);
 	loadGeneralSettings(obj);
 	loadHotkeys(obj);
-	loadDock(obj);
 }
 
 void SwitcherData::saveSettings(obs_data_t *obj)
@@ -487,7 +486,6 @@ void SwitcherData::saveSettings(obs_data_t *obj)
 	saveSceneTriggers(obj);
 	saveGeneralSettings(obj);
 	saveHotkeys(obj);
-	saveDock(obj);
 	saveVersion(obj, g_GIT_SHA1);
 }
 

--- a/src/headers/status-control.hpp
+++ b/src/headers/status-control.hpp
@@ -38,7 +38,4 @@ public:
 	StatusDock(QWidget *parent = 0);
 };
 
-extern StatusDock *dock;
-
-void saveDock(obs_data_t *obj);
-void loadDock(obs_data_t *obj);
+void SetupDock();

--- a/src/status-control.cpp
+++ b/src/status-control.cpp
@@ -5,6 +5,7 @@
 #include <obs-module.h>
 #include <QMainWindow>
 #include <QLayout>
+#include <QAction>
 
 StatusDock *dock = nullptr;
 
@@ -94,6 +95,11 @@ void StatusControl::SetStopped()
 StatusDock::StatusDock(QWidget *parent)
 	: QDockWidget(obs_module_text("AdvSceneSwitcher.windowTitle"), parent)
 {
+	setFloating(true);
+	// Setting a fixed object name is crucial for OBS to be able to restore
+	// the docks position, if the dock is not floating
+	setObjectName("Adv-ss-dock");
+
 	// Not sure why an extra QWidget wrapper is necessary...
 	// without it the dock widget seems to be partially transparent.
 	QWidget *tmp = new QWidget;
@@ -103,26 +109,11 @@ StatusDock::StatusDock(QWidget *parent)
 	setWidget(tmp);
 }
 
-void saveDock(obs_data_t *obj)
+void SetupDock()
 {
-	obs_data_set_bool(obj, "statusDockVisible", dock->isVisible());
-	obs_data_set_bool(obj, "statusDockFloating", dock->isFloating());
-	obs_data_set_int(obj, "statusDockPosX", dock->pos().x());
-	obs_data_set_int(obj, "statusDockPosY", dock->pos().y());
-	obs_data_set_int(obj, "statusDockPosWidth", dock->width());
-	obs_data_set_int(obj, "statusDockPosHeight", dock->height());
-}
-
-void loadDock(obs_data_t *obj)
-{
-	dock->setVisible(obs_data_get_bool(obj, "statusDockVisible"));
-	dock->setFloating(obs_data_get_bool(obj, "statusDockFloating"));
-	QPoint pos = {
-		static_cast<int>(obs_data_get_int(obj, "statusDockPosX")),
-		static_cast<int>(obs_data_get_int(obj, "statusDockPosY"))};
-	if (windowPosValid(pos)) {
-		dock->resize(obs_data_get_int(obj, "statusDockPosWidth"),
-			     obs_data_get_int(obj, "statusDockPosHeight"));
-		dock->move(pos);
-	}
+	dock = new StatusDock(
+		static_cast<QMainWindow *>(obs_frontend_get_main_window()));
+	// Added for cosmetic reasons to avoid brief flash of dock window on startup
+	dock->setVisible(false);
+	static_cast<QAction *>(obs_frontend_add_dock(dock));
 }


### PR DESCRIPTION
OBS will handle the docking position / window size and position as long
as an object name is set