### PR TITLE
Fix scene switch action blocking unexpectedly

### DIFF
--- a/src/macro-action-scene-switch.cpp
+++ b/src/macro-action-scene-switch.cpp
@@ -40,7 +40,7 @@ bool MacroActionSwitchScene::PerformAction()
 	auto scene = _scene.GetScene();
 	switchScene({scene, _transition.GetTransition(),
 		     (int)(_duration.seconds * 1000)});
-	if (_blockUntilTransitionDone) {
+	if (_blockUntilTransitionDone && scene) {
 		waitForTransitionChange(scene);
 		return !switcher->abortMacroWait;
 	}


### PR DESCRIPTION
If "wait for transition" was checked and no valid scene was selected the
waitForTransitionChange() function will wait for its maximum allowed
duration as switcher->currentScene will never be null.