### PR TITLE
Make date "At"-type check more robust

### DIFF
--- a/src/headers/macro-condition-date.hpp
+++ b/src/headers/macro-condition-date.hpp
@@ -48,8 +48,8 @@ public:
 	bool _dayOfWeekCheck = false;
 
 private:
-	bool checkDayOfWeek();
-	bool checkRegularDate();
+	bool CheckDayOfWeek(int64_t);
+	bool CheckRegularDate(int64_t);
 
 	static bool _registered;
 	static const std::string id;

--- a/src/headers/macro.hpp
+++ b/src/headers/macro.hpp
@@ -78,6 +78,7 @@ public:
 	bool PerformActions(bool forceParallel = false,
 			    bool ignorePause = false);
 	bool Matched() { return _matched; }
+	int64_t MsSinceLastCheck();
 	std::string Name() { return _name; }
 	void SetName(const std::string &name);
 	void SetRunInParallel(bool parallel) { _runInParallel = parallel; }
@@ -138,6 +139,8 @@ private:
 	// UI helpers for the macro tab
 	bool _wasExecutedRecently = false;
 	bool _onChangeTriggered = false;
+
+	std::chrono::high_resolution_clock::time_point _lastCheckTime{};
 
 	bool _die = false;
 	bool _stop = false;

--- a/src/macro.cpp
+++ b/src/macro.cpp
@@ -126,7 +126,7 @@ bool Macro::CeckMatch()
 	if (_matched && _count != std::numeric_limits<int>::max()) {
 		_count++;
 	}
-
+	_lastCheckTime = std::chrono::high_resolution_clock::now();
 	return _matched;
 }
 
@@ -152,6 +152,18 @@ bool Macro::PerformActions(bool forceParallel, bool ignorePause)
 	return ret;
 }
 
+int64_t Macro::MsSinceLastCheck()
+{
+	if (_lastCheckTime.time_since_epoch().count() == 0) {
+		return 0;
+	}
+	const auto timePassed =
+		std::chrono::high_resolution_clock::now() - _lastCheckTime;
+	return std::chrono::duration_cast<std::chrono::milliseconds>(timePassed)
+		       .count() +
+	       1;
+}
+
 void Macro::SetName(const std::string &name)
 {
 	_name = name;
@@ -163,6 +175,7 @@ void Macro::ResetTimers()
 	for (auto &c : _conditions) {
 		c->ResetDuration();
 	}
+	_lastCheckTime = {};
 }
 
 void Macro::RunActions(bool &retVal, bool ignorePause)


### PR DESCRIPTION
Previously the "At" check could skip the desired time window if e.g another
macro was performing a long wait wait action or condition was taking
a long time to check.
The date condition will now take into consideration when the last time
was the condition checked a date instead of simply applying a fixed
window of "switcher->interval".