### PR TITLE
Fix UI elements shifting slightly

### DIFF
--- a/src/macro-action-transition.cpp
+++ b/src/macro-action-transition.cpp
@@ -330,6 +330,7 @@ void MacroActionTransitionEdit::SetWidgetVisibility()
 		_entryData->_type == MacroActionTransition::Type::SOURCE_SHOW);
 	_scenes->setVisible(_entryData->_type !=
 			    MacroActionTransition::Type::SCENE);
+	adjustSize();
 }
 
 void MacroActionTransitionEdit::SetTransitionChanged(int state)

--- a/src/scene-item-selection.cpp
+++ b/src/scene-item-selection.cpp
@@ -125,6 +125,7 @@ SceneItemSelectionWidget::SceneItemSelectionWidget(QWidget *parent,
 	QWidget::connect(_idx, SIGNAL(currentIndexChanged(int)), this,
 			 SLOT(IdxChanged(int)));
 	auto layout = new QHBoxLayout;
+	layout->setContentsMargins(0, 0, 0, 0);
 	layout->addWidget(_idx);
 	layout->addWidget(_sceneItems);
 	setLayout(layout);


### PR DESCRIPTION
Content margins of scene item selection widget would cause Transition
action to shift slightly whenever the widget's visibility changed