### PR TITLE
Fix crash when deleting last macro

### DIFF
--- a/src/macro-action-edit.cpp
+++ b/src/macro-action-edit.cpp
@@ -220,11 +220,11 @@ void AdvSceneSwitcher::RemoveMacroAction(int idx)
 
 	{
 		std::lock_guard<std::mutex> lock(switcher->m);
+		actionsList->Remove(idx);
 		macro->Actions().erase(macro->Actions().begin() + idx);
 		switcher->abortMacroWait = true;
 		switcher->macroWaitCv.notify_all();
 		macro->UpdateActionIndices();
-		actionsList->Remove(idx);
 		SetActionData(*macro);
 	}
 	MacroActionSelectionChanged(-1);

--- a/src/macro-condition-edit.cpp
+++ b/src/macro-condition-edit.cpp
@@ -437,13 +437,13 @@ void AdvSceneSwitcher::RemoveMacroCondition(int idx)
 
 	{
 		std::lock_guard<std::mutex> lock(switcher->m);
+		conditionsList->Remove(idx);
 		macro->Conditions().erase(macro->Conditions().begin() + idx);
 		macro->UpdateConditionIndices();
 		if (idx == 0 && macro->Conditions().size() > 0) {
 			auto newRoot = macro->Conditions().at(0);
 			newRoot->SetLogicType(LogicType::ROOT_NONE);
 		}
-		conditionsList->Remove(idx);
 		SetConditionData(*macro);
 	}
 	MacroConditionSelectionChanged(-1);

--- a/src/macro-tab.cpp
+++ b/src/macro-tab.cpp
@@ -98,20 +98,19 @@ void AdvSceneSwitcher::on_macroRemove_clicked()
 	if (!item) {
 		return;
 	}
+	int idx = ui->macros->currentRow();
+	delete item;
 	QString name;
 	{
 		std::lock_guard<std::mutex> lock(switcher->m);
 		switcher->abortMacroWait = true;
 		switcher->macroWaitCv.notify_all();
-		int idx = ui->macros->currentRow();
 		QString::fromStdString(switcher->macros[idx]->Name());
 		switcher->macros.erase(switcher->macros.begin() + idx);
 		for (auto &m : switcher->macros) {
 			m->ResolveMacroRef();
 		}
 	}
-
-	delete item;
 
 	if (ui->macros->count() == 0) {
 		ui->macroHelp->setVisible(true);
@@ -360,6 +359,10 @@ void AdvSceneSwitcher::on_macros_currentRowChanged(int idx)
 
 	if (idx == -1) {
 		SetMacroEditAreaDisabled(true);
+		conditionsList->Clear();
+		actionsList->Clear();
+		conditionsList->SetHelpMsgVisible(true);
+		actionsList->SetHelpMsgVisible(true);
 		return;
 	}
 


### PR DESCRIPTION
A crash could occur if the last macro was deleted and the highlighting
of macro segments was enabled due to the macro segments already being
deleted while the widgets representing these segments were not