### PR TITLE
Set screenshot file extension to *.png

### DIFF
--- a/src/external-macro-modules/opencv/macro-condition-video.cpp
+++ b/src/external-macro-modules/opencv/macro-condition-video.cpp
@@ -566,7 +566,7 @@ void MacroConditionVideoEdit::ImageBrowseButtonClicked()
 		ScreenshotHelper screenshot(source);
 		obs_source_release(source);
 
-		path = QFileDialog::getSaveFileName(this);
+		path = QFileDialog::getSaveFileName(this, "", "", "*.png");
 		if (path.isEmpty()) {
 			return;
 		}


### PR DESCRIPTION
Files without any file extension are not properly loaded as an QImage and
thus pattern matching might not work