### PR TITLE
Add special handling for the "between" case when ignoring the date

### DIFF
--- a/src/macro-core/macro-condition-date.cpp
+++ b/src/macro-core/macro-condition-date.cpp
@@ -67,6 +67,26 @@ bool MacroConditionDate::CheckDayOfWeek(int64_t msSinceLastCheck)
 	return false;
 }
 
+bool MacroConditionDate::CheckBetween(QDateTime &now)
+{
+	// In the case of ignoring the date component treat the "left" value as
+	// the start of the time range and the "right" value as the end
+	if (_ignoreDate) {
+		if (_dateTime2 >= _dateTime) {
+			return now >= _dateTime && now <= _dateTime2;
+		}
+		// Assume that the end / start value should be shifted by 24h
+		// as otherwise the condition would never be true
+		return (now >= _dateTime && now <= _dateTime2.addDays(1)) ||
+		       (now >= _dateTime.addDays(-1) && now <= _dateTime2);
+	}
+
+	if (_dateTime2 >= _dateTime) {
+		return now >= _dateTime && now <= _dateTime2;
+	}
+	return now >= _dateTime2 && now <= _dateTime;
+}
+
 bool MacroConditionDate::CheckRegularDate(int64_t msSinceLastCheck)
 {
 	bool match = false;
@@ -92,11 +112,7 @@ bool MacroConditionDate::CheckRegularDate(int64_t msSinceLastCheck)
 		match = cur <= _dateTime;
 		break;
 	case DateCondition::BETWEEN:
-		if (_dateTime2 > _dateTime) {
-			match = cur >= _dateTime && cur <= _dateTime2;
-		} else {
-			match = cur >= _dateTime2 && cur <= _dateTime;
-		}
+		match = CheckBetween(cur);
 		break;
 	default:
 		break;

--- a/src/macro-core/macro-condition-date.hpp
+++ b/src/macro-core/macro-condition-date.hpp
@@ -58,6 +58,7 @@ public:
 private:
 	bool CheckDayOfWeek(int64_t);
 	bool CheckRegularDate(int64_t);
+	bool CheckBetween(QDateTime &now);
 
 	QDateTime _dateTime = QDateTime::currentDateTime();
 	QDateTime _dateTime2 = QDateTime::currentDateTime();


### PR DESCRIPTION
In this case the left time value will be treated as the start of the time range and the right one as the end.

This now enables specifying ranges that span over the 24h boundary. E.g. 23:00:00 to 01:00:00.
This would have previously been treated as 01:00:00 to 23:00:00 instead.