### PR TITLE
Do not allow running paused macros

### DIFF
--- a/src/macro-core/macro-action-macro.cpp
+++ b/src/macro-core/macro-action-macro.cpp
@@ -36,7 +36,9 @@ bool MacroActionMacro::PerformAction()
 		_macro->ResetCount();
 		break;
 	case PerformMacroAction::RUN:
-		_macro->PerformActions();
+		if (!_macro->Paused()) {
+			_macro->PerformActions();
+		}
 		break;
 	case PerformMacroAction::STOP:
 		_macro->Stop();


### PR DESCRIPTION
The old behaviour was not consistent with the other action types. (E.g. "Sequence" or "Random" ignore paused macros) It would also only ever execute the first action of the given macro as afterwards the plugin would realise the macro is paused and abort the execution.