### PR TITLE
Resolve variables even when calling const functions

### DIFF
--- a/src/utils/variable-number.hpp
+++ b/src/utils/variable-number.hpp
@@ -36,4 +36,7 @@ private:
 
 #include "variable-number.tpp"
 
+using IntVariable = NumberVariable<int>;
+using DoubleVariable = NumberVariable<double>;
+
 } // namespace advss

--- a/src/utils/variable-string.cpp
+++ b/src/utils/variable-string.cpp
@@ -4,7 +4,7 @@
 
 namespace advss {
 
-void StringVariable::Resolve()
+void StringVariable::Resolve() const
 {
 	if (switcher->variables.empty()) {
 		_resolvedValue = _value;
@@ -17,7 +17,7 @@ void StringVariable::Resolve()
 	_lastResolve = GetLastVariableChangeTime();
 }
 
-StringVariable::operator std::string()
+StringVariable::operator std::string() const
 {
 	Resolve();
 	return _resolvedValue;
@@ -59,7 +59,7 @@ const char *StringVariable::c_str()
 
 const char *StringVariable::c_str() const
 {
-	// Just assume that the value was previously resolved already
+	Resolve();
 	return _resolvedValue.c_str();
 }
 

--- a/src/utils/variable-string.hpp
+++ b/src/utils/variable-string.hpp
@@ -14,7 +14,7 @@ public:
 	StringVariable() : _value(""){};
 	StringVariable(std::string str) : _value(std::move(str)){};
 	StringVariable(const char *str) : _value(str){};
-	operator std::string();
+	operator std::string() const;
 	operator QVariant() const;
 	void operator=(std::string);
 	void operator=(const char *value);
@@ -27,11 +27,11 @@ public:
 	void Save(obs_data_t *obj, const char *name) const;
 
 private:
-	void Resolve();
+	void Resolve() const;
 
 	std::string _value = "";
-	std::string _resolvedValue = "";
-	std::chrono::high_resolution_clock::time_point _lastResolve{};
+	mutable std::string _resolvedValue = "";
+	mutable std::chrono::high_resolution_clock::time_point _lastResolve{};
 };
 
 std::string SubstitueVariables(std::string str);


### PR DESCRIPTION
This is done to ensure that logs printed before actions are executed contain the correct parameter values instead of potentially outdated ones.