### PR TITLE
Fix crash for brightness condition

### DIFF
--- a/src/macro-external/video/opencv-helpers.cpp
+++ b/src/macro-external/video/opencv-helpers.cpp
@@ -100,6 +100,10 @@ std::vector<cv::Rect> matchObject(QImage &img, cv::CascadeClassifier &cascade,
 
 uchar getAvgBrightness(QImage &img)
 {
+	if (img.isNull()) {
+		return 0;
+	}
+
 	auto i = QImageToMat(img);
 	cv::Mat hsvImage, rgbImage;
 	cv::cvtColor(i, rgbImage, cv::COLOR_RGBA2RGB);


### PR DESCRIPTION
This will prevent a crash when the brightness is calculated and the source has no output (yet).