### PR TITLE
Reduce size of audio action widget

### DIFF
--- a/src/macro-core/macro-action-audio.cpp
+++ b/src/macro-core/macro-action-audio.cpp
@@ -437,11 +437,11 @@ void MacroActionAudioEdit::SetWidgetVisibility()
 	_balance->setVisible(_entryData->_action ==
 			     MacroActionAudio::Action::BALANCE);
 
-	_fadeTypes->setDisabled(!_entryData->_fade);
-	_wait->setDisabled(!_entryData->_fade);
-	_abortActiveFade->setDisabled(!_entryData->_fade);
-	_duration->setDisabled(!_entryData->_fade);
-	_rate->setDisabled(!_entryData->_fade);
+	_fadeTypes->setEnabled(_entryData->_fade);
+	_wait->setEnabled(_entryData->_fade);
+	_abortActiveFade->setEnabled(_entryData->_fade);
+	_duration->setEnabled(_entryData->_fade);
+	_rate->setEnabled(_entryData->_fade);
 
 	_fadeTypeLayout->removeWidget(_fade);
 	_fadeTypeLayout->removeWidget(_fadeTypes);
@@ -474,6 +474,10 @@ void MacroActionAudioEdit::SetWidgetVisibility()
 			 hasVolumeControl(_entryData->_action));
 	SetLayoutVisible(_fadeOptionsLayout,
 			 hasVolumeControl(_entryData->_action));
+	_abortActiveFade->setVisible(_entryData->_fade);
+	_wait->setVisible(_entryData->_fade);
+
+	updateGeometry();
 	adjustSize();
 }
 

--- a/src/macro-external/midi/CMakeLists.txt
+++ b/src/macro-external/midi/CMakeLists.txt
@@ -12,6 +12,10 @@ if(NOT EXISTS "${LIBREMIDI_DIR}")
 endif()
 add_subdirectory("${LIBREMIDI_DIR}" "${LIBREMIDI_DIR}/build" EXCLUDE_FROM_ALL)
 
+if(MSVC)
+  target_compile_options(libremidi PRIVATE /wd4251 /wd4267 /wd4275)
+endif(MSVC)
+
 # --- End of section ---
 
 add_library(${PROJECT_NAME} MODULE)


### PR DESCRIPTION
Only show audio fade options when they are needed.