### PR TITLE
Fix window condition ignoring title matching if regex is disabled

### DIFF
--- a/src/macro-core/macro-condition-window.hpp
+++ b/src/macro-core/macro-condition-window.hpp
@@ -21,10 +21,6 @@ public:
 		return std::make_shared<MacroConditionWindow>(m);
 	}
 
-private:
-	bool WindowMatches(const std::string &window);
-	bool WindowRegexMatches(const std::vector<std::string> &windowList);
-
 public:
 	StringVariable _window;
 	RegexConfig _windowRegex;
@@ -40,6 +36,11 @@ public:
 	RegexConfig _textRegex = RegexConfig::PartialMatchRegexConfig();
 
 private:
+	bool WindowMatchesRequirements(const std::string &window) const;
+	bool WindowMatches(const std::vector<std::string> &windowList);
+	bool WindowRegexMatches(const std::vector<std::string> &windowList);
+	void SetVariableValueBasedOnMatch(const std::string &matchWindow);
+
 	static bool _registered;
 	static const std::string id;
 };


### PR DESCRIPTION
If the only enabled option was window title matching and regular expressions were not used any window title would match regardless if it existed or not