### PR TITLE
Add tooltips for variable text inputs

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -830,6 +830,8 @@ AdvSceneSwitcher.variable.save.dontSave="Don't save variable value"
 AdvSceneSwitcher.variable.save.save="Save variable value"
 AdvSceneSwitcher.variable.save.default="Set to value"
 
+AdvSceneSwitcher.tooltip.availableVariables="Variables are supported, use ${VarName} to retrieve the value of VarName"
+
 AdvSceneSwitcher.connection.select="--select connection--"
 AdvSceneSwitcher.connection.add="Add new connection"
 AdvSceneSwitcher.connection.configure="Configure connection settings"

--- a/src/utils/variable-line-edit.cpp
+++ b/src/utils/variable-line-edit.cpp
@@ -1,8 +1,14 @@
 #include "variable-line-edit.hpp"
 
+#include <obs-module.h>
+
 namespace advss {
 
-VariableLineEdit::VariableLineEdit(QWidget *parent) : QLineEdit(parent) {}
+VariableLineEdit::VariableLineEdit(QWidget *parent) : QLineEdit(parent)
+{
+	QLineEdit::setToolTip(
+		obs_module_text("AdvSceneSwitcher.tooltip.availableVariables"));
+}
 
 void VariableLineEdit::setText(const QString &string)
 {
@@ -12,6 +18,13 @@ void VariableLineEdit::setText(const QString &string)
 void VariableLineEdit::setText(const StringVariable &string)
 {
 	QLineEdit::setText(QString::fromStdString(string.UnresolvedValue()));
+}
+
+void VariableLineEdit::setToolTip(const QString &string)
+{
+	QLineEdit::setToolTip(
+		string + "\n" +
+		obs_module_text("AdvSceneSwitcher.tooltip.availableVariables"));
 }
 
 } // namespace advss

--- a/src/utils/variable-line-edit.hpp
+++ b/src/utils/variable-line-edit.hpp
@@ -11,6 +11,7 @@ public:
 	VariableLineEdit(QWidget *parent);
 	void setText(const QString &);
 	void setText(const StringVariable &);
+	void setToolTip(const QString &string);
 
 private:
 };

--- a/src/utils/variable-text-edit.cpp
+++ b/src/utils/variable-text-edit.cpp
@@ -1,11 +1,15 @@
 #include "variable-text-edit.hpp"
 #include "switcher-data.hpp"
 
+#include <obs-module.h>
+
 namespace advss {
 
 VariableTextEdit::VariableTextEdit(QWidget *parent)
 	: ResizingPlainTextEdit(parent)
 {
+	QPlainTextEdit::setToolTip(
+		obs_module_text("AdvSceneSwitcher.tooltip.availableVariables"));
 }
 
 void VariableTextEdit::setPlainText(const QString &string)
@@ -17,6 +21,13 @@ void VariableTextEdit::setPlainText(const StringVariable &string)
 {
 	QPlainTextEdit::setPlainText(
 		QString::fromStdString(string.UnresolvedValue()));
+}
+
+void VariableTextEdit::setToolTip(const QString &string)
+{
+	QPlainTextEdit::setToolTip(
+		string + "\n" +
+		obs_module_text("AdvSceneSwitcher.tooltip.availableVariables"));
 }
 
 } // namespace advss

--- a/src/utils/variable-text-edit.hpp
+++ b/src/utils/variable-text-edit.hpp
@@ -10,6 +10,7 @@ public:
 	VariableTextEdit(QWidget *parent);
 	void setPlainText(const QString &);
 	void setPlainText(const StringVariable &);
+	void setToolTip(const QString &string);
 
 private:
 };


### PR DESCRIPTION
![image](https://github.com/WarmUpTill/SceneSwitcher/assets/3606072/5e4cc371-69d8-4fd8-a422-e5ffa83e8b6d)

Just a small simple QoL change that should help users realize variables can be used in text fields and what's their format. For now that was only listed in some paragraph in documentation here, which isn't easily findable info.

Not perfect yet, it could be further improved by adding some kind of marking to the fields that tooltip is available, but that's good for a start and I'll attempt to improve it in the future maybe.