### PR TITLE
CI: Fix MacOS builds

### DIFF
--- a/.github/scripts/Build-Windows.ps1
+++ b/.github/scripts/Build-Windows.ps1
@@ -71,7 +71,7 @@ function Build {
 
     (Get-Content -Path ${ProjectRoot}/CMakeLists.txt -Raw) `
         -replace "project\((.*) VERSION (.*)\)", "project(${ProductName} VERSION ${ProductVersion})" `
-    | Out-File -Path ${ProjectRoot}/CMakeLists.txt
+    | Out-File -Path ${ProjectRoot}/CMakeLists.txt -NoNewline
 
     Setup-Obs
 

--- a/.github/scripts/utils.zsh/check_packages
+++ b/.github/scripts/utils.zsh/check_packages
@@ -24,7 +24,7 @@ if (( ! ${+commands[packagesbuild]} )) {
   pushd
   mkcd ${project_root:h}/obs-build-dependencies
 
-  local packages_url='http://s.sudre.free.fr/Software/files/Packages.dmg'
+  local packages_url='https://web.archive.org/web/20230727054218/http://s.sudre.free.fr/Software/files/Packages.dmg'
   local packages_hash='6afdd25386295974dad8f078b8f1e41cabebd08e72d970bf92f707c7e48b16c9'
 
   if [[ ! -f Packages.dmg ]] {


### PR DESCRIPTION
This is just a temporary fix.
The real solution would be to switch to the new OBS plugin template version and no longer rely on the packages app