### PR TITLE
Add max length validation support for TextEdit

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -830,6 +830,8 @@ AdvSceneSwitcher.item.nameReserved="Name reserved!"
 
 AdvSceneSwitcher.macroSegmentSelection.invalid="Invalid selection!"
 
+AdvSceneSwitcher.validation.text.maxLength="Only %1 characters are allowed in this field!"
+
 AdvSceneSwitcher.variable.select="--select variable--"
 AdvSceneSwitcher.variable.add="Add new variable"
 AdvSceneSwitcher.variable.configure="Configure variable settings"

--- a/src/macro-external/twitch/macro-action-twitch.cpp
+++ b/src/macro-external/twitch/macro-action-twitch.cpp
@@ -352,6 +352,7 @@ MacroActionTwitchEdit::MacroActionTwitchEdit(
 	_markerDescription->setMaxLength(140);
 	_announcementMessage->setSizePolicy(QSizePolicy::MinimumExpanding,
 					    QSizePolicy::Preferred);
+	_announcementMessage->setMaxLength(500);
 
 	auto spinBox = _duration->SpinBox();
 	spinBox->setSuffix("s");

--- a/src/utils/resizing-text-edit.cpp
+++ b/src/utils/resizing-text-edit.cpp
@@ -1,5 +1,8 @@
 #include "resizing-text-edit.hpp"
 
+#include <obs-module.h>
+#include <utility.hpp>
+
 namespace advss {
 
 ResizingPlainTextEdit::ResizingPlainTextEdit(QWidget *parent,
@@ -13,6 +16,18 @@ ResizingPlainTextEdit::ResizingPlainTextEdit(QWidget *parent,
 {
 	QWidget::connect(this, SIGNAL(textChanged()), this,
 			 SLOT(ResizeTexteditArea()));
+	QWidget::connect(this, SIGNAL(textChanged()), this,
+			 SLOT(PreventExceedingMaxLength()));
+}
+
+int ResizingPlainTextEdit::maxLength()
+{
+	return _maxLength;
+}
+
+void ResizingPlainTextEdit::setMaxLength(int maxLength)
+{
+	_maxLength = maxLength;
 }
 
 void ResizingPlainTextEdit::ResizeTexteditArea()
@@ -30,6 +45,21 @@ void ResizingPlainTextEdit::ResizeTexteditArea()
 
 	adjustSize();
 	updateGeometry();
+}
+
+void ResizingPlainTextEdit::PreventExceedingMaxLength()
+{
+	auto plainText = QPlainTextEdit::toPlainText();
+
+	if (_maxLength > -1 && plainText.length() > _maxLength) {
+		QPlainTextEdit::setPlainText(plainText.left(_maxLength));
+		QPlainTextEdit::moveCursor(QTextCursor::End);
+
+		DisplayMessage(
+			QString(obs_module_text(
+					"AdvSceneSwitcher.validation.text.maxLength"))
+				.arg(QString::number(_maxLength)));
+	}
 }
 
 } // namespace advss

--- a/src/utils/resizing-text-edit.hpp
+++ b/src/utils/resizing-text-edit.hpp
@@ -10,13 +10,18 @@ public:
 			      const int minLines = 3,
 			      const int paddingLines = 2);
 	virtual ~ResizingPlainTextEdit(){};
+	int maxLength();
+	void setMaxLength(int maxLength);
+
 private slots:
 	void ResizeTexteditArea();
+	void PreventExceedingMaxLength();
 
 private:
 	const int _scrollAt;
 	const int _minLines;
 	const int _paddingLines;
+	int _maxLength = -1;
 };
 
 } // namespace advss

--- a/src/utils/variable-line-edit.cpp
+++ b/src/utils/variable-line-edit.cpp
@@ -1,6 +1,7 @@
 #include "variable-line-edit.hpp"
 
 #include <obs-module.h>
+#include <utility.hpp>
 
 namespace advss {
 
@@ -8,6 +9,9 @@ VariableLineEdit::VariableLineEdit(QWidget *parent) : QLineEdit(parent)
 {
 	QLineEdit::setToolTip(
 		obs_module_text("AdvSceneSwitcher.tooltip.availableVariables"));
+
+	QWidget::connect(this, SIGNAL(inputRejected()), this,
+			 SLOT(DisplayValidationMessages()));
 }
 
 void VariableLineEdit::setText(const QString &string)
@@ -25,6 +29,18 @@ void VariableLineEdit::setToolTip(const QString &string)
 	QLineEdit::setToolTip(
 		string + "\n" +
 		obs_module_text("AdvSceneSwitcher.tooltip.availableVariables"));
+}
+
+void VariableLineEdit::DisplayValidationMessages()
+{
+	int maxLength = QLineEdit::maxLength();
+
+	if (QLineEdit::text().length() == maxLength) {
+		DisplayMessage(
+			QString(obs_module_text(
+					"AdvSceneSwitcher.validation.text.maxLength"))
+				.arg(QString::number(maxLength)));
+	}
 }
 
 } // namespace advss

--- a/src/utils/variable-line-edit.hpp
+++ b/src/utils/variable-line-edit.hpp
@@ -13,6 +13,9 @@ public:
 	void setText(const StringVariable &);
 	void setToolTip(const QString &string);
 
+private slots:
+	void DisplayValidationMessages();
+
 private:
 };
 


### PR DESCRIPTION
![image](https://github.com/WarmUpTill/SceneSwitcher/assets/3606072/530c0437-60e9-4959-b90d-696bad7fa840)

Adds `maxLength` support to `TextEdit`, then also consitently displays message for `LineEdit`. Should be ready to merge from my side