### PR TITLE
Enhance Twitch conditions/widgets + refactors

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -541,7 +541,7 @@ AdvSceneSwitcher.condition.twitch.type.polling.channel.live="Stream is currently
 AdvSceneSwitcher.condition.twitch.type.polling.channel.title="Current title matches"
 AdvSceneSwitcher.condition.twitch.type.polling.channel.category="Current category is"
 AdvSceneSwitcher.condition.twitch.categorySelectionDisabled="Cannot select category without selecting a Twitch account first!"
-AdvSceneSwitcher.condition.twitch.entry="Channel{{channel}}{{conditions}}{{streamTitle}}{{regex}}{{category}}"
+AdvSceneSwitcher.condition.twitch.entry="Channel{{channel}}{{conditions}}{{pointsReward}}{{streamTitle}}{{regex}}{{category}}"
 AdvSceneSwitcher.condition.twitch.entry.account="Check using account{{account}}"
 AdvSceneSwitcher.condition.twitch.tokenPermissionsInsufficient="Permissions of selected token are insufficient to perform selected action!"
 AdvSceneSwitcher.condition.twitch.title.title="Enter title"
@@ -1035,7 +1035,10 @@ AdvSceneSwitcher.twitchToken.channel.redemptions.manage="Manage channel's point 
 AdvSceneSwitcher.twitchToken.channel.moderate="Moderate the channel."
 AdvSceneSwitcher.twitchToken.channel.moderation.read="Read channel's moderation data."
 
-AdvSceneSwitcher.channel.open="Show channel"
+AdvSceneSwitcher.twitch.selection.channel.open="Open channel"
+AdvSceneSwitcher.twitch.selection.channel.open.tooltip.details="Open channel in external application handling the HTTPS protocol."
+AdvSceneSwitcher.twitch.selection.channel.open.tooltip.noAccount="Unable to check if channel exists without selecting a Twitch account first!"
+AdvSceneSwitcher.twitch.selection.channel.open.tooltip.noChannel="Channel with specified name was not found!"
 
 AdvSceneSwitcher.twitchCategories.fetchStart="Fetching stream categories ..."
 AdvSceneSwitcher.twitchCategories.fetchStatus="Got %1 stream categories."
@@ -1048,6 +1051,14 @@ AdvSceneSwitcher.twitchCategories.noViewersCategoriesMissing="Categories without
 AdvSceneSwitcher.twitchCategories.searchFailed="No new categories were found for \"%1\"."
 AdvSceneSwitcher.twitchCategories.searchSuccess="%1 new categories were found for \"%2\" and were added to the list!"
 AdvSceneSwitcher.twitchCategories.select="--select category--"
+
+AdvSceneSwitcher.twitch.selection.points.reward.placeholder="--select points reward--"
+AdvSceneSwitcher.twitch.selection.points.reward.refresh="Manually refresh the list"
+AdvSceneSwitcher.twitch.selection.points.reward.option.any="Any"
+AdvSceneSwitcher.twitch.selection.points.reward.tooltip.noAccount="Can't select points reward without selecting a Twitch account first!"
+AdvSceneSwitcher.twitch.selection.points.reward.tooltip.noPermission="Can't select points reward because of insufficient token permissions!"
+AdvSceneSwitcher.twitch.selection.points.reward.tooltip.noChannel="Can't select points reward without entering a channel first!"
+AdvSceneSwitcher.twitch.selection.points.reward.tooltip.error="Can't select points reward because Twitch responded with an error! Check OBS logs for more details."
 
 AdvSceneSwitcher.selectScene="--select scene--"
 AdvSceneSwitcher.selectPreviousScene="Previous Scene"

--- a/src/macro-external/twitch/CMakeLists.txt
+++ b/src/macro-external/twitch/CMakeLists.txt
@@ -48,6 +48,8 @@ target_sources(
           macro-action-twitch.hpp
           macro-condition-twitch.cpp
           macro-condition-twitch.hpp
+          points-reward-selection.cpp
+          points-reward-selection.hpp
           token.cpp
           token.hpp
           twitch-helpers.cpp

--- a/src/macro-external/twitch/category-selection.hpp
+++ b/src/macro-external/twitch/category-selection.hpp
@@ -116,6 +116,7 @@ class TwitchCategoryWidget : public QWidget {
 
 public:
 	TwitchCategoryWidget(QWidget *parent);
+
 	// Will *not* verify if ID is still valid or populate the selection
 	// list as that would take too long
 	void SetCategory(const TwitchCategory &);
@@ -129,8 +130,6 @@ signals:
 private:
 	TwitchCategorySelection *_selection;
 	TwitchCategorySearchButton *_manualSearch;
-
-	std::weak_ptr<TwitchToken> _token;
 };
 
 // Helper class to ease singal / slot handling

--- a/src/macro-external/twitch/channel-selection.hpp
+++ b/src/macro-external/twitch/channel-selection.hpp
@@ -48,7 +48,8 @@ struct ChannelInfo {
 struct TwitchChannel {
 	void Load(obs_data_t *obj);
 	void Save(obs_data_t *obj) const;
-	std::string GetUserID(const TwitchToken &);
+	StringVariable GetName() const { return _name; };
+	std::string GetUserID(const TwitchToken &token) const;
 	bool IsValid(const std::string &id) const;
 	std::optional<ChannelLiveInfo> GetLiveInfo(const TwitchToken &);
 	std::optional<ChannelInfo> GetInfo(const TwitchToken &);
@@ -64,11 +65,13 @@ class TwitchChannelSelection : public QWidget {
 
 public:
 	TwitchChannelSelection(QWidget *parent);
-	void SetChannel(const TwitchChannel &);
+	void SetChannel(const TwitchChannel &channel);
+	void SetToken(const std::weak_ptr<TwitchToken> &token);
 
 private slots:
 	void SelectionChanged();
 	void OpenChannel();
+	void SetOpenChannelState(const TwitchChannel &channel);
 
 signals:
 	void ChannelChanged(const TwitchChannel &);
@@ -76,6 +79,8 @@ signals:
 private:
 	VariableLineEdit *_channelName;
 	QPushButton *_openChannel;
+
+	std::weak_ptr<TwitchToken> _token;
 };
 
 } // namespace advss

--- a/src/macro-external/twitch/macro-action-twitch.hpp
+++ b/src/macro-external/twitch/macro-action-twitch.hpp
@@ -13,17 +13,12 @@ namespace advss {
 class MacroActionTwitch : public MacroAction {
 public:
 	MacroActionTwitch(Macro *m) : MacroAction(m) {}
-	bool PerformAction();
-	void LogAction() const;
-	bool Save(obs_data_t *obj) const;
-	bool Load(obs_data_t *obj);
-	std::string GetShortDesc() const;
-	std::string GetId() const { return id; };
 	static std::shared_ptr<MacroAction> Create(Macro *m)
 	{
 		return std::make_shared<MacroActionTwitch>(m);
 	}
-	bool ActionIsSupportedByToken();
+	std::string GetId() const { return id; };
+	std::string GetShortDesc() const;
 
 	enum class Action {
 		TITLE,
@@ -44,6 +39,12 @@ public:
 		ORANGE,
 		PURPLE,
 	};
+
+	bool PerformAction();
+	void LogAction() const;
+	bool Save(obs_data_t *obj) const;
+	bool Load(obs_data_t *obj);
+	bool ActionIsSupportedByToken();
 
 	Action _action = Action::TITLE;
 	std::weak_ptr<TwitchToken> _token;
@@ -81,7 +82,6 @@ public:
 	MacroActionTwitchEdit(
 		QWidget *parent,
 		std::shared_ptr<MacroActionTwitch> entryData = nullptr);
-	void UpdateEntryData();
 	static QWidget *Create(QWidget *parent,
 			       std::shared_ptr<MacroAction> action)
 	{
@@ -89,6 +89,7 @@ public:
 			parent,
 			std::dynamic_pointer_cast<MacroActionTwitch>(action));
 	}
+	void UpdateEntryData();
 
 private slots:
 	void ActionChanged(int);
@@ -112,12 +113,13 @@ protected:
 private:
 	void SetupWidgetVisibility();
 
+	bool _loading = true;
+
 	QHBoxLayout *_layout;
 	FilterComboBox *_actions;
 	TwitchConnectionSelection *_tokens;
 	QLabel *_tokenPermissionWarning;
 	QTimer _tokenPermissionCheckTimer;
-
 	VariableLineEdit *_streamTitle;
 	TwitchCategoryWidget *_category;
 	VariableLineEdit *_markerDescription;
@@ -126,8 +128,6 @@ private:
 	VariableTextEdit *_announcementMessage;
 	QComboBox *_announcementColor;
 	TwitchChannelSelection *_channel;
-
-	bool _loading = true;
 };
 
 } // namespace advss

--- a/src/macro-external/twitch/points-reward-selection.cpp
+++ b/src/macro-external/twitch/points-reward-selection.cpp
@@ -1,0 +1,219 @@
+#include "points-reward-selection.hpp"
+#include "twitch-helpers.hpp"
+
+#include <obs-module.h>
+#include <utility.hpp>
+
+namespace advss {
+
+void TwitchPointsReward::Load(obs_data_t *obj)
+{
+	OBSDataAutoRelease data = obs_data_get_obj(obj, "pointsReward");
+	id = obs_data_get_string(data, "id");
+	title = obs_data_get_string(data, "title");
+}
+
+void TwitchPointsReward::Save(obs_data_t *obj) const
+{
+	OBSDataAutoRelease data = obs_data_create();
+	obs_data_set_string(data, "id", id.c_str());
+	obs_data_set_string(data, "title", title.c_str());
+	obs_data_set_obj(obj, "pointsReward", data);
+}
+
+TwitchPointsRewardSelection::TwitchPointsRewardSelection(QWidget *parent,
+							 bool allowAny)
+	: FilterComboBox(
+		  parent,
+		  obs_module_text(
+			  "AdvSceneSwitcher.twitch.selection.points.reward.placeholder")),
+	  _allowAny(allowAny)
+{
+	setDuplicatesEnabled(true);
+	setSizeAdjustPolicy(QComboBox::AdjustToContents);
+
+	QWidget::connect(this, SIGNAL(currentIndexChanged(int)), this,
+			 SLOT(SelectionChanged(int)));
+}
+
+void TwitchPointsRewardSelection::SetPointsReward(
+	const TwitchPointsReward &pointsReward)
+{
+	int index = findData(QString::fromStdString(pointsReward.id));
+	if (index != -1) {
+		setCurrentIndex(index);
+		return;
+	}
+
+	setCurrentIndex(-1);
+}
+
+void TwitchPointsRewardSelection::SetChannel(const TwitchChannel &channel)
+{
+	_channel = channel;
+	PopulateSelection();
+}
+
+void TwitchPointsRewardSelection::SetToken(
+	const std::weak_ptr<TwitchToken> &token)
+{
+	_token = token;
+
+	if (token.expired()) {
+		DisplayErrorMessage(obs_module_text(
+			"AdvSceneSwitcher.twitch.selection.points.reward.tooltip.noAccount"));
+		return;
+	}
+
+	PopulateSelection();
+}
+
+void TwitchPointsRewardSelection::PopulateSelection()
+{
+	auto token = _token.lock();
+
+	if (!token || !token->AnyOptionIsEnabled(SUPPORTED_TOKEN_OPTIONS)) {
+		DisplayErrorMessage(obs_module_text(
+			"AdvSceneSwitcher.twitch.selection.points.reward.tooltip.noPermission"));
+		return;
+	}
+
+	if (!_channel || (*_channel).GetName().empty()) {
+		DisplayErrorMessage(obs_module_text(
+			"AdvSceneSwitcher.twitch.selection.points.reward.tooltip.noChannel"));
+		return;
+	}
+
+	auto currentSelection = currentText();
+	const QSignalBlocker b(this);
+	clear();
+
+	auto pointsRewards = GetPointsRewards(token, *_channel);
+	if (!pointsRewards) {
+		DisplayErrorMessage(obs_module_text(
+			"AdvSceneSwitcher.twitch.selection.points.reward.tooltip.error"));
+		return;
+	}
+
+	HideErrorMessage();
+	AddPredefinedItems();
+
+	for (const auto &pointsReward : *pointsRewards) {
+		addItem(QString::fromStdString(pointsReward.title),
+			QString::fromStdString(pointsReward.id));
+	}
+
+	setCurrentText(currentSelection);
+}
+
+void TwitchPointsRewardSelection::AddPredefinedItems()
+{
+	if (_allowAny) {
+		addItem(obs_module_text(
+				"AdvSceneSwitcher.twitch.selection.points.reward.option.any"),
+			"-");
+	}
+}
+
+void TwitchPointsRewardSelection::DisplayErrorMessage(const char *errorMessage)
+{
+	setDisabled(true);
+	setToolTip(errorMessage);
+}
+
+void TwitchPointsRewardSelection::HideErrorMessage()
+{
+	setDisabled(false);
+	setToolTip("");
+}
+
+std::optional<std::vector<TwitchPointsReward>>
+TwitchPointsRewardSelection::GetPointsRewards(
+	const std::shared_ptr<TwitchToken> &token, const TwitchChannel &channel)
+{
+	httplib::Params params = {
+		{"broadcaster_id", channel.GetUserID(*token)}};
+
+	auto response = SendGetRequest("https://api.twitch.tv",
+				       "/helix/channel_points/custom_rewards",
+				       *token, params);
+
+	if (response.status != 200) {
+		blog(LOG_WARNING,
+		     "Failed to fetch points rewards for user %s and channel %s! (%d)",
+		     token->GetName().c_str(), channel.GetName().c_str(),
+		     response.status);
+
+		return {};
+	}
+
+	return ParseResponse(response.data);
+}
+
+std::vector<TwitchPointsReward>
+TwitchPointsRewardSelection::ParseResponse(obs_data_t *response)
+{
+	std::vector<TwitchPointsReward> pointRewards;
+	OBSDataArrayAutoRelease jsonArray =
+		obs_data_get_array(response, "data");
+	size_t count = obs_data_array_count(jsonArray);
+
+	for (size_t i = 0; i < count; ++i) {
+		OBSDataAutoRelease jsonObj = obs_data_array_item(jsonArray, i);
+		std::string id = obs_data_get_string(jsonObj, "id");
+		std::string title = obs_data_get_string(jsonObj, "title");
+		pointRewards.push_back({id, title});
+	}
+
+	return pointRewards;
+}
+
+void TwitchPointsRewardSelection::SelectionChanged(int index)
+{
+	TwitchPointsReward pointsReward{
+		itemData(index).toString().toStdString(),
+		currentText().toStdString()};
+	emit PointsRewardChanged(pointsReward);
+}
+
+TwitchPointsRewardWidget::TwitchPointsRewardWidget(QWidget *parent)
+	: QWidget(parent),
+	  _selection(new TwitchPointsRewardSelection(this)),
+	  _refreshButton(new QPushButton(this))
+{
+	_refreshButton->setMaximumWidth(22);
+	SetButtonIcon(_refreshButton, ":res/images/refresh.svg");
+	_refreshButton->setToolTip(obs_module_text(
+		"AdvSceneSwitcher.twitch.selection.points.reward.refresh"));
+
+	auto layout = new QHBoxLayout();
+	layout->setContentsMargins(0, 0, 0, 0);
+	layout->addWidget(_selection);
+	layout->addWidget(_refreshButton);
+	setLayout(layout);
+
+	QWidget::connect(
+		_selection,
+		SIGNAL(PointsRewardChanged(const TwitchPointsReward &)), this,
+		SIGNAL(PointsRewardChanged(const TwitchPointsReward &)));
+	QWidget::connect(_refreshButton, SIGNAL(clicked()), _selection,
+			 SLOT(PopulateSelection()));
+}
+
+void TwitchPointsRewardWidget::SetPointsReward(
+	const TwitchPointsReward &pointsReward)
+{
+	_selection->SetPointsReward(pointsReward);
+}
+
+void TwitchPointsRewardWidget::SetChannel(const TwitchChannel &channel)
+{
+	_selection->SetChannel(channel);
+}
+
+void TwitchPointsRewardWidget::SetToken(const std::weak_ptr<TwitchToken> &token)
+{
+	_selection->SetToken(token);
+}
+
+} // namespace advss

--- a/src/macro-external/twitch/points-reward-selection.hpp
+++ b/src/macro-external/twitch/points-reward-selection.hpp
@@ -1,0 +1,74 @@
+#pragma once
+#include "channel-selection.hpp"
+#include "token.hpp"
+
+#include <filter-combo-box.hpp>
+#include <obs-data.h>
+#include <string>
+
+namespace advss {
+
+struct TwitchPointsReward {
+	void Load(obs_data_t *obj);
+	void Save(obs_data_t *obj) const;
+
+	std::string id = "-";
+	std::string title = "-";
+};
+
+class TwitchPointsRewardSelection : public FilterComboBox {
+	Q_OBJECT
+
+public:
+	TwitchPointsRewardSelection(QWidget *parent, bool allowAny = true);
+
+	void SetPointsReward(const TwitchPointsReward &pointsReward);
+	void SetChannel(const TwitchChannel &channel);
+	void SetToken(const std::weak_ptr<TwitchToken> &token);
+
+protected:
+	void DisplayErrorMessage(const char *errorMessage);
+	void HideErrorMessage();
+
+	std::optional<TwitchChannel> _channel = {};
+	std::weak_ptr<TwitchToken> _token;
+
+private:
+	void AddPredefinedItems();
+	std::optional<std::vector<TwitchPointsReward>>
+	GetPointsRewards(const std::shared_ptr<TwitchToken> &token,
+			 const TwitchChannel &channel);
+	std::vector<TwitchPointsReward> ParseResponse(obs_data_t *response);
+
+	bool _allowAny;
+	const std::vector<TokenOption> SUPPORTED_TOKEN_OPTIONS = {
+		{"channel:read:redemptions"},
+		{"channel:manage:redemptions"}};
+
+private slots:
+	void PopulateSelection();
+	void SelectionChanged(int);
+
+signals:
+	void PointsRewardChanged(const TwitchPointsReward &);
+};
+
+class TwitchPointsRewardWidget : public QWidget {
+	Q_OBJECT
+
+public:
+	TwitchPointsRewardWidget(QWidget *parent);
+
+	void SetPointsReward(const TwitchPointsReward &pointsReward);
+	void SetChannel(const TwitchChannel &channel);
+	void SetToken(const std::weak_ptr<TwitchToken> &token);
+
+signals:
+	void PointsRewardChanged(const TwitchPointsReward &);
+
+protected:
+	TwitchPointsRewardSelection *_selection;
+	QPushButton *_refreshButton;
+};
+
+} // namespace advss

--- a/src/macro-external/twitch/token.cpp
+++ b/src/macro-external/twitch/token.cpp
@@ -172,6 +172,22 @@ bool TwitchToken::OptionIsEnabled(const TokenOption &option) const
 	return false;
 }
 
+bool TwitchToken::AnyOptionIsEnabled(
+	const std::vector<TokenOption> &options) const
+{
+	if (options.empty()) {
+		return true;
+	}
+
+	for (const auto &tokenOption : options) {
+		if (OptionIsEnabled(tokenOption)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void TwitchToken::SetToken(const std::string &value)
 {
 	_token = value;

--- a/src/macro-external/twitch/token.hpp
+++ b/src/macro-external/twitch/token.hpp
@@ -41,7 +41,8 @@ public:
 	void Load(obs_data_t *obj);
 	void Save(obs_data_t *obj) const;
 	std::string GetName() { return _name; }
-	bool OptionIsEnabled(const TokenOption &) const;
+	bool OptionIsEnabled(const TokenOption &option) const;
+	bool AnyOptionIsEnabled(const std::vector<TokenOption> &options) const;
 	void SetToken(const std::string &);
 	bool IsEmpty() const { return _token.empty(); }
 	std::optional<std::string> GetToken() const;

--- a/src/utils/variable-string.cpp
+++ b/src/utils/variable-string.cpp
@@ -63,6 +63,12 @@ const char *StringVariable::c_str() const
 	return _resolvedValue.c_str();
 }
 
+bool StringVariable::empty() const
+{
+	Resolve();
+	return _resolvedValue.empty();
+}
+
 std::string SubstitueVariables(std::string str)
 {
 	if (!switcher) {

--- a/src/utils/variable-string.hpp
+++ b/src/utils/variable-string.hpp
@@ -20,6 +20,7 @@ public:
 	void operator=(const char *value);
 	const char *c_str();
 	const char *c_str() const;
+	bool empty() const;
 
 	const std::string &UnresolvedValue() const { return _value; }
 


### PR DESCRIPTION
Additions:
- point reward conditions support filtering by `reward_id` optionally, with new selection widget:
![image](https://github.com/WarmUpTill/SceneSwitcher/assets/3606072/9f962626-8332-4210-bc19-2ad9ba7bee4f)

- channel selection widget now disables the button if channel doesn't exist (also fixed small bug resulting from channel change not emitted when changed programatically, only when editing finished)

Fixes:
- https://github.com/WarmUpTill/SceneSwitcher/issues/905 - added a function that can verify multiple scopes with "or"
- channel changes in condition not resetting subscription ID

Refactors:
- simplified Twitch condition logic to match the subscription ID rather than broadcaster ID and some other data - worked well for me, as I mentioned not sure why it wasn't done this way in the 1st place (but if there's a reason let me know)
- further made ordering more consistent so that Twitch macros/conditions are easier to read (more or less samethematical order in hpp and cpp)
- removed some unused code
- added some param names to some header files to functions that I modified - if you're wondering why, this makes parameter hints in VSCode work faster/more consistently (would be nice if they were included generally)

I also have some action changes stashed, but I'd like to get this merged first as the PR could get too confusing. I'll push the changes somewhen this week, I might also add more custom conditions to that.