### PR TITLE
Add else actions toggle button

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -126,6 +126,8 @@ AdvSceneSwitcher.macroTab.currentDockButtonText.unpause="Unpause button text:"
 AdvSceneSwitcher.macroTab.currentDockStatusText.true="Conditions true text:"
 AdvSceneSwitcher.macroTab.currentDockStatusText.false="Conditions false text:"
 AdvSceneSwitcher.macroTab.currentDockHighlightIfExecuted="Highlight dock if macro actions were recently executed"
+AdvSceneSwitcher.macroTab.toggleElseActions.hide.tooltip="Hide else actions"
+AdvSceneSwitcher.macroTab.toggleElseActions.show.tooltip="Show else actions"
 
 AdvSceneSwitcher.macroDock.pause="Pause"
 AdvSceneSwitcher.macroDock.unpause="Unpause"

--- a/data/res/images/DarkNotEqual.svg
+++ b/data/res/images/DarkNotEqual.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" version="1.1">
+ <!-- Created with SVG-edit - https://github.com/SVG-Edit/svgedit-->
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <rect fill="#fefefe" height="2.25" id="svg_1" stroke="#fefefe" stroke-dasharray="null" stroke-linecap="null" stroke-linejoin="null" transform="matrix(1, 0, 0, 1, 0, 0)" width="13" x="1.5" y="4"/>
+  <rect fill="#fefefe" height="2.25" id="svg_2" stroke="#fefefe" stroke-dasharray="null" stroke-linecap="null" stroke-linejoin="null" transform="matrix(1, 0, 0, 1, 0, 0)" width="13" x="1.5" y="10"/>
+  <rect fill="#fefefe" height="1" id="svg_4" stroke="#fefefe" stroke-dasharray="null" stroke-linecap="null" stroke-linejoin="null" transform="matrix(0.341951, -0.926734, 0.939718, 0.337226, -1.948, 13.2448)" width="14" x="1" y="7"/>
+ </g>
+</svg>

--- a/data/res/images/LightNotEqual.svg
+++ b/data/res/images/LightNotEqual.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" version="1.1">
+ <!-- Created with SVG-edit - https://github.com/SVG-Edit/svgedit-->
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <rect fill="#202020" height="2.25" id="svg_1" stroke="#202020" stroke-dasharray="null" stroke-linecap="null" stroke-linejoin="null" transform="matrix(1, 0, 0, 1, 0, 0)" width="13" x="1.5" y="4"/>
+  <rect fill="#202020" height="2.25" id="svg_2" stroke="#202020" stroke-dasharray="null" stroke-linecap="null" stroke-linejoin="null" transform="matrix(1, 0, 0, 1, 0, 0)" width="13" x="1.5" y="10"/>
+  <rect fill="#202020" height="1" id="svg_4" stroke="#202020" stroke-dasharray="null" stroke-linecap="null" stroke-linejoin="null" transform="matrix(0.341951, -0.926734, 0.939718, 0.337226, -1.948, 13.2448)" width="14" x="1" y="7"/>
+ </g>
+</svg>

--- a/forms/advanced-scene-switcher.ui
+++ b/forms/advanced-scene-switcher.ui
@@ -1275,6 +1275,22 @@
                     </property>
                    </spacer>
                   </item>
+                  <item>
+                   <widget class="QPushButton" name="toggleElseActions">
+                    <property name="maximumSize">
+                     <size>
+                      <width>22</width>
+                      <height>16777215</height>
+                     </size>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="flat">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
                  </layout>
                 </item>
                </layout>

--- a/src/advanced-scene-switcher.cpp
+++ b/src/advanced-scene-switcher.cpp
@@ -115,6 +115,23 @@ void AdvSceneSwitcher::LoadUI()
 	loading = false;
 }
 
+bool AdvSceneSwitcher::eventFilter(QObject *obj, QEvent *event)
+{
+	auto eventType = event->type();
+	if (obj == ui->macroElseActions && eventType == QEvent::Resize) {
+		QResizeEvent *resizeEvent = static_cast<QResizeEvent *>(event);
+
+		if (resizeEvent->size().height() == 0) {
+			SetElseActionsStateToHidden();
+			return QDialog::eventFilter(obj, event);
+		}
+
+		SetElseActionsStateToVisible();
+	}
+
+	return QDialog::eventFilter(obj, event);
+}
+
 /******************************************************************************
  * Saving and loading
  ******************************************************************************/

--- a/src/advanced-scene-switcher.hpp
+++ b/src/advanced-scene-switcher.hpp
@@ -39,6 +39,9 @@ public:
 	void RestoreWindowGeo();
 	void CheckFirstTimeSetup();
 
+protected:
+	bool eventFilter(QObject *obj, QEvent *event) override;
+
 	/* --- Begin of general tab section --- */
 public:
 	void SetupGeneralTab();
@@ -115,6 +118,7 @@ public slots:
 	void on_actionUp_clicked();
 	void on_actionDown_clicked();
 	void on_actionBottom_clicked();
+	void on_toggleElseActions_clicked();
 	void on_elseActionAdd_clicked();
 	void on_elseActionRemove_clicked();
 	void on_elseActionTop_clicked();
@@ -146,6 +150,8 @@ public slots:
 	void MaximizeElseActions();
 	void MinimizeConditions();
 	void MaximizeConditions();
+	void SetElseActionsStateToHidden();
+	void SetElseActionsStateToVisible();
 	void MacroActionSelectionChanged(int idx);
 	void MacroActionReorder(int to, int target);
 	void AddMacroAction(int idx);
@@ -334,7 +340,7 @@ public slots:
 	void on_timeUp_clicked();
 	void on_timeDown_clicked();
 
-	// Video tab
+	// Audio tab
 public:
 	void SetupAudioTab();
 public slots:

--- a/src/macro-core/macro-tab.cpp
+++ b/src/macro-core/macro-tab.cpp
@@ -700,8 +700,7 @@ void AdvSceneSwitcher::MacroSelectionAboutToChange()
 	// actions nor elseActions being visible when the condition <-> action
 	// splitter is moved
 	if (elsePos[0] == 0 && elsePos[1] == 0) {
-		macro->SetElseActionSplitterPosition(QList<int>()
-						     << 999999 << 0);
+		maximizeFirstSplitterEntry(ui->macroElseActionSplitter);
 		return;
 	}
 	macro->SetElseActionSplitterPosition(
@@ -790,6 +789,8 @@ bool shouldRestoreSplitter(const QList<int> &pos)
 
 void AdvSceneSwitcher::SetupMacroTab()
 {
+	ui->macroElseActions->installEventFilter(this);
+
 	if (switcher->macros.size() == 0 && !switcher->disableHints) {
 		addPulse = PulseWidget(ui->macroAdd, QColor(Qt::green));
 	}
@@ -862,6 +863,8 @@ void AdvSceneSwitcher::SetupMacroTab()
 	SetButtonIcon(ui->conditionTop, (pathPrefix + "DoubleUp.svg").c_str());
 	SetButtonIcon(ui->conditionBottom,
 		      (pathPrefix + "DoubleDown.svg").c_str());
+	SetButtonIcon(ui->toggleElseActions,
+		      (pathPrefix + "NotEqual.svg").c_str());
 
 	// Reserve more space for macro edit area than for the macro list
 	ui->macroListMacroEditSplitter->setStretchFactor(0, 1);
@@ -1098,6 +1101,31 @@ void AdvSceneSwitcher::MaximizeConditions()
 {
 	MinimizeElseActions();
 	MinimizeActions();
+}
+
+void AdvSceneSwitcher::on_toggleElseActions_clicked()
+{
+	auto elsePosition = ui->macroElseActionSplitter->sizes();
+	if (elsePosition[1] == 0) {
+		centerSplitterPosition(ui->macroElseActionSplitter);
+		return;
+	}
+
+	maximizeFirstSplitterEntry(ui->macroElseActionSplitter);
+}
+
+void AdvSceneSwitcher::SetElseActionsStateToHidden()
+{
+	ui->toggleElseActions->setToolTip(obs_module_text(
+		"AdvSceneSwitcher.macroTab.toggleElseActions.show.tooltip"));
+	ui->toggleElseActions->setChecked(false);
+}
+
+void AdvSceneSwitcher::SetElseActionsStateToVisible()
+{
+	ui->toggleElseActions->setToolTip(obs_module_text(
+		"AdvSceneSwitcher.macroTab.toggleElseActions.hide.tooltip"));
+	ui->toggleElseActions->setChecked(true);
 }
 
 bool AdvSceneSwitcher::MacroTabIsInFocus()


### PR DESCRIPTION
Some notes:
- `eventFilter` got used to check any sort of resizes in the end because `QSplitters` signals are terrible and `splitterMoved` isn't even triggered when `QSplitter` is changed programatically (maximize, macro change, etc.)
- had no idea what to choose for icons, nothing from OBS/Qt is matching too well IMO (maybe visibility ones, but they're unrelated to "else" itself), so went for strikethrough text instead. Probably custom SVG would be better, but I haven't seen any in Advanced Scene Switcher, so yea. Feel free to change this if needed.

This makes it ofc more clear for users that there's such feature (and also easier to explain how to show it).
![image](https://github.com/WarmUpTill/SceneSwitcher/assets/3606072/522ef96d-4127-4480-8af2-27aa0c440aff)
