### PR TITLE
Enable Area Selection in ScreenshotHelper class

### DIFF
--- a/src/macro-core/macro-action-screenshot.cpp
+++ b/src/macro-core/macro-action-screenshot.cpp
@@ -32,7 +32,7 @@ void MacroActionScreenshot::CustomScreenshot(OBSWeakSource &source)
 	}
 	auto s = obs_weak_source_get_source(source);
 	_screenshot.~ScreenshotHelper();
-	new (&_screenshot) ScreenshotHelper(s, false, 0, true, _path);
+	new (&_screenshot) ScreenshotHelper(s, QRect(), false, 0, true, _path);
 	obs_source_release(s);
 }
 

--- a/src/macro-external/video/macro-condition-video.cpp
+++ b/src/macro-external/video/macro-condition-video.cpp
@@ -215,8 +215,15 @@ void MacroConditionVideo::GetScreenshot(bool blocking)
 {
 	auto source = obs_weak_source_get_source(_video.GetVideo());
 	_screenshotData.~ScreenshotHelper();
-	new (&_screenshotData)
-		ScreenshotHelper(source, blocking, GetSwitcher()->interval);
+	QRect screenshotArea;
+	if (_areaParameters.enable && _condition != VideoCondition::NO_IMAGE) {
+		screenshotArea.setRect(_areaParameters.area.x,
+				       _areaParameters.area.y,
+				       _areaParameters.area.width,
+				       _areaParameters.area.height);
+	}
+	new (&_screenshotData) ScreenshotHelper(
+		source, screenshotArea, blocking, GetSwitcher()->interval);
 	obs_source_release(source);
 	_getNextScreenshot = false;
 }
@@ -361,13 +368,6 @@ bool MacroConditionVideo::CheckColor()
 
 bool MacroConditionVideo::Compare()
 {
-	if (_areaParameters.enable && _condition != VideoCondition::NO_IMAGE) {
-		_screenshotData.image = _screenshotData.image.copy(
-			_areaParameters.area.x, _areaParameters.area.y,
-			_areaParameters.area.width,
-			_areaParameters.area.height);
-	}
-
 	if (_condition != VideoCondition::OCR) {
 		SetVariableValue("");
 	}

--- a/src/macro-external/video/preview-dialog.cpp
+++ b/src/macro-external/video/preview-dialog.cpp
@@ -255,7 +255,13 @@ void PreviewImage::CreateImage(const VideoInput &video, PreviewType type,
 			       VideoCondition condition)
 {
 	auto source = obs_weak_source_get_source(video.GetVideo());
-	ScreenshotHelper screenshot(source, true);
+	QRect screenshotArea;
+	if (areaParams.enable && type == PreviewType::SHOW_MATCH) {
+		screenshotArea.setRect(areaParams.area.x, areaParams.area.y,
+				       areaParams.area.width,
+				       areaParams.area.height);
+	}
+	ScreenshotHelper screenshot(source, screenshotArea, true);
 	obs_source_release(source);
 
 	if (!video.ValidSelection() || !screenshot.done) {
@@ -274,11 +280,6 @@ void PreviewImage::CreateImage(const VideoInput &video, PreviewType type,
 
 	if (type == PreviewType::SHOW_MATCH) {
 		std::unique_lock<std::mutex> lock(_mtx);
-		if (areaParams.enable) {
-			screenshot.image = screenshot.image.copy(
-				areaParams.area.x, areaParams.area.y,
-				areaParams.area.width, areaParams.area.height);
-		}
 		// Will emit status label update
 		MarkMatch(screenshot.image, patternMatchParams,
 			  patternImageData, objDetectParams, ocrParams,

--- a/src/utils/screenshot-helper.hpp
+++ b/src/utils/screenshot-helper.hpp
@@ -12,9 +12,9 @@ namespace advss {
 class ScreenshotHelper {
 public:
 	ScreenshotHelper() = default;
-	ScreenshotHelper(obs_source_t *source, bool blocking = false,
-			 int timeout = 1000, bool saveToFile = false,
-			 std::string path = "");
+	ScreenshotHelper(obs_source_t *source, const QRect &subarea = QRect(),
+			 bool blocking = false, int timeout = 1000,
+			 bool saveToFile = false, std::string path = "");
 	ScreenshotHelper &operator=(const ScreenshotHelper &) = delete;
 	ScreenshotHelper(const ScreenshotHelper &) = delete;
 	~ScreenshotHelper();
@@ -39,6 +39,7 @@ public:
 
 private:
 	std::atomic_bool _initDone = false;
+	QRect _subarea = QRect();
 	bool _blocking = false;
 	std::thread _saveThread;
 	bool _saveToFile = false;


### PR DESCRIPTION
This change gives the option to pass an area of interest to the ScreenshotHelper class, and it will then only render that part.

Previously, the data out of the area of interest was dismissed much later (and I think on the CPU, if I read the functions used correctly).

Returned images are equal on the pixel level as far as I could see, also with respect to the bounds.