### PR TITLE
Fix EOL character for using the formatter via WSL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/build-aux/*.zsh eol=lf
+/build-aux/.functions/* eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 !/tests
 !.clang-format
 !.cmake-format.json
+!.gitattributes
 !.gitignore
 !BUILDING.md
 !buildspec.json


### PR DESCRIPTION
This PR fixes the checked-out EOL characters for zsh scripts when using Windows primarily.

The formatter script is then best run through WSL, but zsh doesn't like (putting it lightly) the CRLF on either the script nor its imported functions.

I could have included the build scripts here, but I didn't want to affect the .github folder and building via WSL doesn't really make sense anyway.