### PR TITLE
Save settings when switching to new macro

### DIFF
--- a/lib/macro/macro-tab.cpp
+++ b/lib/macro/macro-tab.cpp
@@ -13,6 +13,7 @@
 #include "utility.hpp"
 #include "version.h"
 
+#include <obs-frontend-api.h>
 #include <QColor>
 #include <QGraphicsOpacityEffect>
 #include <QMenu>
@@ -729,6 +730,7 @@ void AdvSceneSwitcher::MacroSelectionChanged()
 		return;
 	}
 	SetEditMacro(*macro);
+	obs_frontend_save();
 }
 
 void AdvSceneSwitcher::HighlightOnChange()

--- a/lib/variables/variable-tab.cpp
+++ b/lib/variables/variable-tab.cpp
@@ -102,7 +102,6 @@ static void removeVariableRow(QTableWidget *table, const QString &name)
 
 static void updateVaribleStatus(QTableWidget *table)
 {
-	auto lock = LockContext();
 	for (int row = 0; row < table->rowCount(); row++) {
 		auto item = table->item(row, 0);
 		if (!item) {

--- a/plugins/base/macro-condition-audio.cpp
+++ b/plugins/base/macro-condition-audio.cpp
@@ -67,7 +67,7 @@ bool MacroConditionAudio::CheckOutputCondition()
 	OBSSourceAutoRelease source =
 		obs_weak_source_get_source(_audioSource.GetSource());
 
-	double curVolume = _useDb ? _peak : DecibelToPercent(_peak);
+	double curVolume = _useDb ? _peak : DecibelToPercent(_peak) * 100;
 
 	switch (_outputCondition) {
 	case OutputCondition::ABOVE:


### PR DESCRIPTION
This should ensure that settings are saved more frequently and less data is lost in case the plugin crashes with the settings dialog opened.