### PR TITLE
Disabled bogus GCC string overflow error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,7 +383,7 @@ if(NOT OS_WINDOWS)
     ${LIB_NAME}
     PUBLIC -Wno-error=unused-parameter -Wno-error=conversion -Wno-error=shadow
            -Wno-error=float-conversion -Wno-error=enum-conversion
-           -Wno-error=deprecated-declarations)
+           -Wno-error=deprecated-declarations -Wno-error=stringop-overflow)
 endif()
 
 # --- End of section ---


### PR DESCRIPTION
GCC has some logic to detect string overflow. Unfortunately, it's broken and gives many false positives.

* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114379
* https://aur.archlinux.org/packages/obs-advanced-scene-switcher

This commit just disables the compiler warning/error.

I'm not even sure if this is the right place to disable this warning, as I'm not familiar with CMake. (Will it also affect other compilers? Would other compilers complain about this flag?) But at least it manages to fully compile the project.