### PR TITLE
Fix checkbox icon of groups in macro tree not being set on OBS 30.1.2

### DIFF
--- a/lib/macro/macro-tree.cpp
+++ b/lib/macro/macro-tree.cpp
@@ -173,6 +173,7 @@ void MacroTreeItem::Update(bool force)
 
 	} else if (_type == Type::Group) {
 		_expand = new SourceTreeSubItemCheckBox();
+		_expand->setProperty("sourceTreeSubItem", true);
 		_expand->setSizePolicy(QSizePolicy::Maximum,
 				       QSizePolicy::Maximum);
 		_expand->setMaximumSize(10, 16);

--- a/lib/macro/macro-tree.hpp
+++ b/lib/macro/macro-tree.hpp
@@ -17,6 +17,7 @@ class QSpacerItem;
 class QHBoxLayout;
 
 // Only used to enable applying "SourceTreeSubItemCheckBox" stylesheet
+// Can be removed once the minimum supported OBS version is greater than 30.1
 class SourceTreeSubItemCheckBox : public QCheckBox {
 	Q_OBJECT
 };


### PR DESCRIPTION
This change is necessary because of
https://github.com/obsproject/obs-studio/pull/9584