### PR TITLE
Assume minimum volume when no volume update was received within 250ms

### DIFF
--- a/plugins/base/macro-condition-audio.hpp
+++ b/plugins/base/macro-condition-audio.hpp
@@ -71,12 +71,14 @@ private:
 	bool CheckMonitor();
 	bool CheckBalance();
 	void SetupTempVars();
+	float GetVolumePeak();
 
 	Type _checkType = Type::OUTPUT_VOLUME;
 	std::mutex _peakMutex;
 	float _peak = -std::numeric_limits<float>::infinity();
 	float _previousPeak = -std::numeric_limits<float>::infinity();
 	bool _peakUpdated = false;
+	std::chrono::high_resolution_clock::time_point _lastPeakUpdate = {};
 	static bool _registered;
 	static const std::string id;
 };


### PR DESCRIPTION
Without this timeout the peak volume update, which was received last, would be used permanently until the next update arrives. This might only take place when the source produces audio output again.