### PR TITLE
Increase volume meter scale from -100 to 0 dB

### DIFF
--- a/lib/utils/volume-control.cpp
+++ b/lib/utils/volume-control.cpp
@@ -619,7 +619,7 @@ VolumeMeter::VolumeMeter(QWidget *parent, obs_volmeter_t *obs_volmeter,
 	magnitudeColor.setRgb(0x00, 0x00, 0x00); // Black
 	majorTickColor.setRgb(0xff, 0xff, 0xff); // Black
 	minorTickColor.setRgb(0xcc, 0xcc, 0xcc); // Black
-	minimumLevel = -60.0;                    // -60 dB
+	minimumLevel = -100.0;                   // -100 dB
 	warningLevel = -20.0;                    // -20 dB
 	errorLevel = -9.0;                       //  -9 dB
 	clipLevel = -0.5;                        //  -0.5 dB

--- a/plugins/base/macro-condition-audio.cpp
+++ b/plugins/base/macro-condition-audio.cpp
@@ -657,7 +657,7 @@ void MacroConditionAudioEdit::SyncSliderAndValueSelection(bool sliderMoved)
 	if (sliderMoved) {
 		auto sliderPosition = _volMeter->GetSlider()->DoubleValue();
 		// Adjust to the dB scale on the volume meter widget
-		auto dBScaleValue = ((sliderPosition * 3.0) / 5.0) - 60.0;
+		auto dBScaleValue = sliderPosition - 100.0;
 
 		if (_entryData->_useDb) {
 			_volumeDB->SetFixedValue(dBScaleValue);
@@ -677,7 +677,7 @@ void MacroConditionAudioEdit::SyncSliderAndValueSelection(bool sliderMoved)
 				? _entryData->_volumeDB.GetFixedValue()
 				: PercentToDecibel(_entryData->_volumePercent /
 						   100.0);
-		auto sliderPosition = (dBValue + 60.0) * 5 / 3.0;
+		auto sliderPosition = (dBValue + 100);
 		_volMeter->GetSlider()->SetDoubleVal(sliderPosition);
 	}
 }


### PR DESCRIPTION
This was done to enable users to to use higher precision values in the "Audio" condition type.
Previously, the UI would reset the selected values to the minimum value possible to display in the volume meter widget, which was -60 dB.