### PR TITLE
Fix connecting Twitch account leading to OBS freeze

### DIFF
--- a/plugins/twitch/chat-connection.cpp
+++ b/plugins/twitch/chat-connection.cpp
@@ -392,6 +392,11 @@ void TwitchChatConnection::Disconnect()
 	if (ec) {
 		blog(LOG_INFO, "TwitchChatConnection close failed: %s",
 		     ec.message().c_str());
+
+		// TODO: avoid using stop()
+		_stop = true;
+		std::this_thread::sleep_for(3s);
+		_client.stop();
 	}
 
 	{


### PR DESCRIPTION
In rare cases the close() call for the Twitch chat connection might fail due to a race condition I have not fully figured out yet. As a workaround the connection to the chat server will be force closed for now.