### PR TITLE
Disable custom macro interval by default

### DIFF
--- a/lib/macro/macro.hpp
+++ b/lib/macro/macro.hpp
@@ -199,7 +199,7 @@ private:
 	bool _isCollapsed = false;
 
 	bool _useShortCircuitEvaluation = false;
-	bool _useCustomConditionCheckInterval = true;
+	bool _useCustomConditionCheckInterval = false;
 	Duration _customConditionCheckInterval = 0.3;
 	bool _conditionSateChanged = false;
 


### PR DESCRIPTION
I don't see any reason for it to be turned on by default with some random default value