### PR TITLE
Fix languageCode in text recognition to work

### DIFF
--- a/plugins/video/parameter-wrappers.cpp
+++ b/plugins/video/parameter-wrappers.cpp
@@ -251,7 +251,8 @@ OCRParameters::OCRParameters(const OCRParameters &other)
 	  regex(other.regex),
 	  color(other.color),
 	  colorThreshold(other.colorThreshold),
-	  pageSegMode(other.pageSegMode)
+	  pageSegMode(other.pageSegMode),
+	  languageCode(other.languageCode)
 {
 	if (!initDone) {
 		Setup();
@@ -268,6 +269,7 @@ OCRParameters &OCRParameters::operator=(const OCRParameters &other)
 	color = other.color;
 	colorThreshold = other.colorThreshold;
 	pageSegMode = other.pageSegMode;
+	languageCode = other.languageCode;
 	if (!initDone) {
 		Setup();
 	}
@@ -329,6 +331,7 @@ bool OCRParameters::SetLanguageCode(const std::string &value)
 	if (!fileInfo.exists(dataPath)) {
 		return false;
 	}
+	languageCode = value;
 	Setup();
 	ocr->SetPageSegMode(pageSegMode);
 	return true;

--- a/plugins/video/parameter-wrappers.cpp
+++ b/plugins/video/parameter-wrappers.cpp
@@ -312,6 +312,7 @@ bool OCRParameters::Load(obs_data_t *obj)
 	if (initDone) {
 		ocr->SetPageSegMode(pageSegMode);
 	}
+	Setup();
 	return true;
 }
 


### PR DESCRIPTION
There is a text field on settings to specify Tesseract's language code but it has not been copied to the OCRParameters struct and thus only `eng.traineddata` can be used as the name of the recognition model.

This PR will fix the restriction of the file name and let users specify any language codes they want.

The OCRParameters struct lacks copying of languageCode on copy constructors and this prevents the recognition preview from working, and this bug needs to be fixed in this PR.

The ocr object must be reinitialized after languageCode is changed and thus Setup() was added in Load()