### PR TITLE
Disable Twitch event timestamp verification by default

### DIFF
--- a/plugins/twitch/token.hpp
+++ b/plugins/twitch/token.hpp
@@ -58,7 +58,7 @@ private:
 	std::string _userID;
 	std::set<TokenOption> _tokenOptions = TokenOption::GetAllTokenOptions();
 	std::shared_ptr<EventSub> _eventSub;
-	bool _validateEventSubTimestamps = true;
+	bool _validateEventSubTimestamps = false;
 
 	static bool _setup;
 


### PR DESCRIPTION
It brakes too often to be worth it as an option to be enabled by default.