### PR TITLE
Fix Twitch event sub reconnect handling

### DIFF
--- a/plugins/twitch/event-sub.hpp
+++ b/plugins/twitch/event-sub.hpp
@@ -110,6 +110,7 @@ private:
 	std::condition_variable _cv;
 	std::atomic_bool _connected{false};
 	std::atomic_bool _disconnect{false};
+	std::atomic_bool _reconnecting{false};
 
 	std::string _url;
 	std::string _sessionID;


### PR DESCRIPTION
If the connection was aborted by the local machine, the active subsciptions were not cleared causing the new connection not attempt to register any new subsciptions.

An event sub connection without any active subsciptions will be dropped by Twitch after a certain amount of time.

Additionally the reconnection logic was triggering to frequently causing unecessary load.