### PR TITLE
CI: Rename "legacy" Windows artifacts to "portable"

### DIFF
--- a/.github/scripts/Package-Windows.ps1
+++ b/.github/scripts/Package-Windows.ps1
@@ -96,25 +96,25 @@ function Package {
     Log-Group
 
     # --- Legacy zip (old layout, extract to OBS install directory) ---
-    Log-Group "Archiving ${ProductName} (legacy)..."
-    $LegStaging = "${ProjectRoot}/release/zip-staging-leg"
-    Remove-Item -Path $LegStaging -Recurse -Force -ErrorAction SilentlyContinue
-    New-Item -ItemType Directory -Force -Path $LegStaging | Out-Null
-    Copy-Item -Path "${CIWindowsDir}/README-legacy.txt" -Destination "${LegStaging}/README.txt"
+    Log-Group "Archiving ${ProductName} (portable)..."
+    $PortableStaging = "${ProjectRoot}/release/zip-staging-portable"
+    Remove-Item -Path $PortableStaging -Recurse -Force -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Force -Path $PortableStaging | Out-Null
+    Copy-Item -Path "${CIWindowsDir}/README-portable.txt" -Destination "${PortableStaging}/README.txt"
     if ( Test-Path -Path $NewBinPath ) {
-        $LegBinPath = "${LegStaging}/obs-plugins/64bit"
-        New-Item -ItemType Directory -Force -Path $LegBinPath | Out-Null
-        Copy-Item -Path "${NewBinPath}/*" -Destination $LegBinPath -Recurse -Force
+        $PortableBinPath = "${PortableStaging}/obs-plugins/64bit"
+        New-Item -ItemType Directory -Force -Path $PortableBinPath | Out-Null
+        Copy-Item -Path "${NewBinPath}/*" -Destination $PortableBinPath -Recurse -Force
     }
     if ( Test-Path -Path $NewDataPath ) {
-        $LegDataPath = "${LegStaging}/data/obs-plugins/${ProductName}"
-        New-Item -ItemType Directory -Force -Path $LegDataPath | Out-Null
-        Copy-Item -Path "${NewDataPath}/*" -Destination $LegDataPath -Recurse -Force
+        $PortableDataPath = "${PortableStaging}/data/obs-plugins/${ProductName}"
+        New-Item -ItemType Directory -Force -Path $PortableDataPath | Out-Null
+        Copy-Item -Path "${NewDataPath}/*" -Destination $PortableDataPath -Recurse -Force
     }
-    Compress-Archive -Force -Path (Get-ChildItem -Path $LegStaging) `
+    Compress-Archive -Force -Path (Get-ChildItem -Path $PortableStaging) `
         -CompressionLevel Optimal `
-        -DestinationPath "${ProjectRoot}/release/${OutputName}-legacy.zip"
-    Remove-Item -Path $LegStaging -Recurse -Force
+        -DestinationPath "${ProjectRoot}/release/${OutputName}-portable.zip"
+    Remove-Item -Path $PortableStaging -Recurse -Force
     Log-Group
 
     if ( ( $BuildInstaller ) ) {
@@ -137,12 +137,12 @@ function Package {
 
         # Legacy layout (for OBS installation directory)
         if ( Test-Path "${Configuration}/${ProductName}/bin/64bit" ) {
-            $PkgLegBin = "Package/legacy/obs-plugins/64bit"
+            $PkgLegBin = "Package/portable/obs-plugins/64bit"
             New-Item -ItemType Directory -Force -Path $PkgLegBin | Out-Null
             Copy-Item -Path "${Configuration}/${ProductName}/bin/64bit/*" -Destination $PkgLegBin -Recurse -Force
         }
         if ( Test-Path "${Configuration}/${ProductName}/data" ) {
-            $PkgLegData = "Package/legacy/data/obs-plugins/${ProductName}"
+            $PkgLegData = "Package/portable/data/obs-plugins/${ProductName}"
             New-Item -ItemType Directory -Force -Path $PkgLegData | Out-Null
             Copy-Item -Path "${Configuration}/${ProductName}/data/*" -Destination $PkgLegData -Recurse -Force
         }

--- a/build-aux/CI/windows/README-portable.txt
+++ b/build-aux/CI/windows/README-portable.txt
@@ -1,11 +1,11 @@
-Advanced Scene Switcher - Windows Installation (Legacy)
-========================================================
+Advanced Scene Switcher - Windows Installation (Portable)
+==========================================================
 
 For full installation instructions visit:
 https://github.com/WarmUpTill/SceneSwitcher/wiki/Installation
 
 
-This archive uses the legacy plugin layout for older OBS versions,
+This archive uses the portable plugin layout for older OBS versions,
 portable OBS installs, and Steam.
 
 Extract the CONTENTS of this archive into your OBS installation directory,

--- a/build-aux/CI/windows/README.txt
+++ b/build-aux/CI/windows/README.txt
@@ -17,5 +17,5 @@ After extracting, the path should look like:
     C:\ProgramData\obs-studio\plugins\advanced-scene-switcher\bin\64bit\advanced-scene-switcher.dll
 
 
-If the plugin does not appear in OBS, try the legacy archive instead:
-    advanced-scene-switcher-<version>-windows-x64-legacy.zip
+If the plugin does not appear in OBS, try the portable archive instead:
+    advanced-scene-switcher-<version>-windows-x64-portable.zip

--- a/cmake/windows/resources/installer-Windows.iss.in
+++ b/cmake/windows/resources/installer-Windows.iss.in
@@ -33,7 +33,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 ; Recommended layout - used when installing to %ProgramData%\obs-studio\plugins\
 Source: "..\release\Package\recommended\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Check: IsRecommendedLayout
 ; Legacy layout - used when installing to the OBS installation directory
-Source: "..\release\Package\legacy\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Check: IsLegacyLayout
+Source: "..\release\Package\portable\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Check: IsLegacyLayout
 Source: "..\LICENSE"; Flags: dontcopy
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
@@ -88,9 +88,9 @@ begin
     Result := PrevPath;
 end;
 
-// Remove files placed by the legacy installer (obs-plugins/64bit and
+// Remove files placed by the portable installer (obs-plugins/64bit and
 // data/obs-plugins layout) so the plugin is not loaded twice by OBS.
-// Only runs when upgrading from a legacy location to the recommended one.
+// Only runs when upgrading from a portable location to the recommended one.
 procedure RemoveLegacyFiles();
 var
   OldInstallPath: string;


### PR DESCRIPTION
This is consistent with the naming used by other plugin developers