### PR TITLE
OpenCV 5 support

### DIFF
--- a/plugins/video/opencv-helpers.hpp
+++ b/plugins/video/opencv-helpers.hpp
@@ -3,6 +3,9 @@
 #undef NO // MacOS macro that can conflict with OpenCV
 #include <cstddef>
 #include <opencv2/opencv.hpp>
+#if CV_VERSION_MAJOR >= 5
+#include <opencv2/xobjdetect.hpp>
+#endif
 
 #ifdef OCR_SUPPORT
 #include <tesseract/baseapi.h>


### PR DESCRIPTION
The [AUR package](https://aur.archlinux.org/packages/obs-advanced-scene-switcher) builds against system OpenCV which has been updated to OpenCV 5 on Arch systems. This patch adds support for OpenCV 5 installations. I didn't update the submodule, that still points to OpenCV 4.10, this just fixes the include when trying to compile against OpenCV 5.

resolves #1669