### PR TITLE
Fix crash in SendWebsocketVendorEvent during OBS shutdown

### DIFF
--- a/lib/utils/websocket-api.cpp
+++ b/lib/utils/websocket-api.cpp
@@ -127,9 +127,10 @@ void RegisterWebsocketRequest(
 
 void SendWebsocketVendorEvent(const std::string &eventName, obs_data_t *data)
 {
-	if (OBSIsShuttingDown()) {
+	if (OBSIsShuttingDown() || !obs_get_module("obs-websocket")) {
 		return;
 	}
+
 	obs_websocket_vendor_emit_event(vendor, eventName.c_str(), data);
 }
 


### PR DESCRIPTION
## Problem

`SendWebsocketVendorEvent()` dereferences a stale proc-handler pointer (`_ph`, cached in `obs-websocket-api.h`) when OBS shuts down, crashing with a use-after-free (`pthread_mutex_unlock` in `w32-pthreads`). Refs #1404.

## Root cause

During `obs_shutdown()` modules are unloaded one-by-one. `obs-websocket` is unloaded before `advanced-scene-switcher`, so when `FreeSceneSwitcher()` runs its stop steps and emits `AdvancedSceneSwitcherStopped`, the `_ph` it cached earlier is already freed. `proc_handler_call(_ph, …)` then crashes.

The existing `OBSIsShuttingDown()` guard does **not** catch this path. In the forced-exit that follows a `Source Cleanup Error` (scene collection switch), the `SCRIPTING_SHUTDOWN` frontend event never fires, so the plugin's `obsIsShuttingDown` flag is never set — the restart-then-stop sequence runs `SendWebsocketVendorEvent()` while the switcher believes it is not in a shutdown context.

## Fix

Add a guard using the public `obs_get_module("obs-websocket")` API (which returns `NULL` once the module is unloaded):

```cpp
if (!obs_get_module("obs-websocket")) {
    return;
}
```

This is the reliable signal that `obs-websocket`'s proc handler is gone, and it costs nothing in the normal path.

## Testing

- Reproduced the crash on OBS 32.2.2 + adv-ss 1.36.1 (3 identical crashes, same stack as the issue).
- Built with this patch and confirmed scene-collection switching + shutdown no longer crash.

## Note

I agree with your earlier assessment that a *resource leak in another plugin* is often the trigger that forces the exit in the first place (in my case it was dangling `source-clone` targets). This patch is a defensive guard so adv-ss does not crash *after* that forced exit — it does not claim to fix the underlying leak.